### PR TITLE
Enable ruff in CI and clear the findings that blocked it

### DIFF
--- a/.github/workflows/django-api.yml
+++ b/.github/workflows/django-api.yml
@@ -52,21 +52,36 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # TODO: add a `lint` job running `ruff check` and `ruff format --check`.
-  # Blocked on a one-off cleanup pass: as of this commit `ruff check` reports
-  # 235 errors (134 auto-fixable; mostly RUF012 mutable class defaults and I001
-  # import ordering) and `ruff format --check` wants to reformat 5 files. The
-  # vendored stubs in typings/ account for ~21 of those and should go in
-  # `[tool.ruff] exclude` rather than being fixed. Adding this job before that
-  # work lands would just make main permanently red.
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Lint
+        run: uv run ruff check --output-format=github
+
+      - name: Check formatting
+        # run even if lint step failed
+        if: always()
+        run: uv run ruff format --check
 
   build:
     name: Build and push Docker image to GHCR
     runs-on: ubuntu-latest
-    needs: test
-    # Pull requests get the test job as their gate. They must not push images:
-    # the tags would be meaningless, and GITHUB_TOKEN on a fork PR has no
-    # packages:write anyway.
+    needs: [test, lint]
+    # Pull requests get the test and lint jobs as their gate. They must not push
+    # images: the tags would be meaningless, and GITHUB_TOKEN on a fork PR has
+    # no packages:write anyway.
     if: github.event_name != 'pull_request'
 
     permissions:

--- a/agenda/tests.py
+++ b/agenda/tests.py
@@ -4,8 +4,7 @@ import random
 from django.test import TestCase
 from django.utils import timezone
 
-from fk.models import Scheduleitem
-from fk.models import Video
+from fk.models import Scheduleitem, Video
 
 from . import views as agenda_views
 

--- a/agenda/tests.py
+++ b/agenda/tests.py
@@ -78,7 +78,7 @@ class FillJukeboxUnitTests(TestCase):
             kwargs["duration"] = datetime.timedelta(minutes=minutes)
         return Video(
             id=video_id,
-            name="id:%d, min:%d" % (video_id, minutes),
+            name=f"id:{video_id}, min:{minutes}",
             creator_id=1,
             organization_id=1,
             proper_import=True,

--- a/agenda/tests.py
+++ b/agenda/tests.py
@@ -1,17 +1,15 @@
 import datetime
 import random
+from zoneinfo import ZoneInfo
 
 from django.test import TestCase
-from django.utils import timezone
 
 from fk.models import Scheduleitem, Video
 
 from . import views as agenda_views
 
-
-def parse_to_datetime(dt_str):
-    dt = datetime.datetime.strptime(dt_str, "%Y-%m-%d %H:%M")
-    return timezone.make_aware(dt, timezone.get_current_timezone())
+OSLO = ZoneInfo("Europe/Oslo")
+START_DATE = datetime.datetime(2019, 6, 30, 12, tzinfo=OSLO)
 
 
 class FillJukeboxIntegrationTests(TestCase):
@@ -26,10 +24,9 @@ class FillJukeboxIntegrationTests(TestCase):
             proper_import=True,
             is_filler=True,
         )
-        start_date = parse_to_datetime("2019-06-30 12:00")
         pre_count = Scheduleitem.objects.count()
 
-        agenda_views.fill_agenda_with_jukebox(start_date, days=1)
+        agenda_views.fill_agenda_with_jukebox(START_DATE, days=1)
 
         self.assertEqual(pre_count + 23, Scheduleitem.objects.count())
 
@@ -42,35 +39,32 @@ class FillJukeboxIntegrationTests(TestCase):
             proper_import=True,
             is_filler=True,
         )
-        start_date = parse_to_datetime("2019-06-30 12:00")
         Scheduleitem.objects.create(
             video_id=1,
-            starttime=start_date - datetime.timedelta(minutes=10),
+            starttime=START_DATE - datetime.timedelta(minutes=10),
             duration=datetime.timedelta(minutes=1),
             schedulereason=Scheduleitem.REASON_AUTO,
         )
         Scheduleitem.objects.create(
             video_id=2,
-            starttime=start_date + datetime.timedelta(hours=6, minutes=0),
+            starttime=START_DATE + datetime.timedelta(hours=6, minutes=0),
             duration=datetime.timedelta(minutes=60),
             schedulereason=Scheduleitem.REASON_AUTO,
         )
         Scheduleitem.objects.create(
             video_id=1,
-            starttime=start_date + datetime.timedelta(hours=24, minutes=10),
+            starttime=START_DATE + datetime.timedelta(hours=24, minutes=10),
             duration=datetime.timedelta(minutes=1),
             schedulereason=Scheduleitem.REASON_AUTO,
         )
         pre_count = Scheduleitem.objects.count()
 
-        agenda_views.fill_agenda_with_jukebox(start_date, days=0.5)
+        agenda_views.fill_agenda_with_jukebox(START_DATE, days=0.5)
 
         self.assertEqual(pre_count + 9, Scheduleitem.objects.count())
 
 
 class FillJukeboxUnitTests(TestCase):
-    start_date = parse_to_datetime("2019-06-30 12:00")
-
     @classmethod
     def _video(cls, video_id=None, minutes=60, **kwargs):
         video_id = video_id or random.randint(0, 1000)
@@ -92,9 +86,9 @@ class FillJukeboxUnitTests(TestCase):
             self._video(video_id=2, minutes=3),
         ]
 
-        end = self.start_date + datetime.timedelta(minutes=15)
+        end = START_DATE + datetime.timedelta(minutes=15)
 
-        res = agenda_views._items_for_gap(self.start_date, end, videos)
+        res = agenda_views._items_for_gap(START_DATE, end, videos)
 
         self.assertEqual([1, 2, 1, 2], [r["id"] for r in res])
 
@@ -103,7 +97,6 @@ class FillJukeboxGapTests(TestCase):
     """Covers the rounding and minimum-gap rules in `_items_for_gap`."""
 
     fixtures = ["test.yaml"]
-    start_date = parse_to_datetime("2019-06-30 12:00")
 
     def test_short_gap_before_scheduled_item_is_left_empty(self):
         """
@@ -121,17 +114,17 @@ class FillJukeboxGapTests(TestCase):
         ]
         Scheduleitem.objects.create(
             video_id=1,
-            starttime=self.start_date + datetime.timedelta(minutes=2, seconds=27),
+            starttime=START_DATE + datetime.timedelta(minutes=2, seconds=27),
             duration=datetime.timedelta(minutes=1),
             schedulereason=Scheduleitem.REASON_AUTO,
         )
-        start = self.start_date + datetime.timedelta(seconds=13)
-        end = self.start_date + datetime.timedelta(minutes=10, seconds=3)
+        start = START_DATE + datetime.timedelta(seconds=13)
+        end = START_DATE + datetime.timedelta(minutes=10, seconds=3)
 
         res = agenda_views._items_for_gap(start, end, videos)
 
         self.assertEqual([1, 3, 1, 3], [r["id"] for r in res])
         self.assertEqual(
-            [self.start_date + datetime.timedelta(minutes=m) for m in (4, 6, 7, 9)],
+            [START_DATE + datetime.timedelta(minutes=m) for m in (4, 6, 7, 9)],
             [r["starttime"] for r in res],
         )

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -32,7 +32,7 @@ class ProgramguideView(TemplateView):
     title = "Program guide - this week"
 
     def get_context_data(self, **kwargs):
-        context = super(ProgramguideView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
 
         if "date" in self.request.GET:
             starttime = parse_datetime(self.request.GET["date"] + " 00:00")
@@ -278,7 +278,7 @@ def floor_minute(dt):
 
 
 def _items_for_gap(start, end, candidates):
-    logger.info("Being asked to fill gap from {} to {}".format(start, end))
+    logger.info(f"Being asked to fill gap from {start} to {end}")
     # The smallest gap this function will try to fill
     MINIMUM_GAP_SECONDS = 300
 
@@ -385,9 +385,7 @@ def _fill_time_with_jukebox(start, end, videos, current_pool=None):
 def xmltv_home(request):
     """Information about the XMLTV schedule presentation."""
     now = timezone.now()
-    today_url = reverse(
-        "xmltv-feed", args=(now.year, "{:02}".format(now.month), "{:02}".format(now.day))
-    )
+    today_url = reverse("xmltv-feed", args=(now.year, f"{now.month:02}", f"{now.day:02}"))
     return render(
         request,
         "agenda/xmltv_home.html",
@@ -422,7 +420,7 @@ def xmltv_upcoming(request):
 
 def xmltv_date(request, year, month, day):
     date = datetime.datetime(year=int(year), month=int(month), day=int(day)).replace(
-        tzinfo=datetime.timezone.utc
+        tzinfo=datetime.UTC
     )
     events = Scheduleitem.objects.by_day(date, days=1).order_by("starttime")
     return _xmltv(request, events)

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -417,8 +417,6 @@ def xmltv_upcoming(request):
 
 
 def xmltv_date(request, year, month, day):
-    date = datetime.datetime(year=int(year), month=int(month), day=int(day)).replace(
-        tzinfo=datetime.UTC
-    )
+    date = datetime.datetime(year=int(year), month=int(month), day=int(day), tzinfo=datetime.UTC)
     events = Scheduleitem.objects.by_day(date, days=1).order_by("starttime")
     return _xmltv(request, events)

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -278,7 +278,7 @@ def floor_minute(dt):
 
 
 def _items_for_gap(start, end, candidates):
-    logger.info(f"Being asked to fill gap from {start} to {end}")
+    logger.info("Being asked to fill gap from %s to %s", start, end)
     # The smallest gap this function will try to fill
     MINIMUM_GAP_SECONDS = 300
 
@@ -325,7 +325,7 @@ def _items_for_gap(start, end, candidates):
             )
             full_items.extend(items)
         else:
-            logging.info("Not filling %d second gap" % gap)
+            logger.info("Not filling %d second gap", gap)
 
         if end_of_gap >= end:
             break
@@ -337,7 +337,7 @@ def _items_for_gap(start, end, candidates):
 def _fill_time_with_jukebox(start, end, videos, current_pool=None):
     current_time = start
     video_pool = current_pool or list(videos)
-    logger.info("Filling jukebox from %s to %s - %d in pool" % (start, end, len(video_pool)))
+    logger.info("Filling jukebox from %s to %s - %d in pool", start, end, len(video_pool))
     rejected_videos = []
     new_items = []
 
@@ -346,9 +346,7 @@ def _fill_time_with_jukebox(start, end, videos, current_pool=None):
 
     def next_vid(first=False):
         logger.debug(Video.objects.all())
-        logger.debug(
-            "next vid %s rej %s pool %s" % (first, plist(rejected_videos), plist(video_pool))
-        )
+        logger.debug("next vid %s rej %s pool %s", first, plist(rejected_videos), plist(video_pool))
         if len(video_pool) < len(videos) and first:
             video_pool.extend(list(videos))
         if len(rejected_videos):
@@ -362,7 +360,7 @@ def _fill_time_with_jukebox(start, end, videos, current_pool=None):
         new_rejects = []
 
         while current_time + video.duration > end:
-            logger.debug("end overshoots time", current_time + video.duration)
+            logger.debug("end overshoots time %s", current_time + video.duration)
             if video not in rejected_videos and video not in new_rejects:
                 new_rejects.append(video)
             video = next_vid()

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -67,7 +67,7 @@ class ManageVideoList(TemplateView):
 
     def get(self, request: HttpRequest, *_args, **_kwargs) -> HttpResponse:
         if not request.user.is_authenticated:
-            return redirect("/login/?next=%s" % request.path)
+            return redirect(f"/login/?next={request.path}")
         videos = Video.objects.filter(creator=request.user).order_by("name")
 
         paginator = Paginator(videos, self.VIDEOS_PER_PAGE)
@@ -154,7 +154,7 @@ class AbstractVideoFormView(TemplateView):
 class ManageVideoNew(AbstractVideoFormView):
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         if not request.user.is_authenticated or not request.user.is_superuser:
-            return redirect("/login/?next=%s" % request.path)
+            return redirect(f"/login/?next={request.path}")
         initial = {}
         form = self.get_form(request, initial=initial, form=kwargs.get("form"))
         context = {"form": form, "title": _("New Video")}
@@ -162,7 +162,7 @@ class ManageVideoNew(AbstractVideoFormView):
 
     def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         if not request.user.is_authenticated or not request.user.is_superuser:
-            return redirect("/login/?next=%s" % request.path)
+            return redirect(f"/login/?next={request.path}")
         if request.user.is_superuser:
             video = Video()
         else:
@@ -190,7 +190,7 @@ class ManageVideoEdit(AbstractVideoFormView):
 
     def get(self, request, id=None, form=None):
         if not request.user.is_authenticated:
-            return redirect("/login/?next=%s" % request.path)
+            return redirect(f"/login/?next={request.path}")
         video = Video.objects.get(id=id)
         if not allowed_to_edit(video, request.user):
             return HttpResponseForbidden(
@@ -203,7 +203,7 @@ class ManageVideoEdit(AbstractVideoFormView):
 
     def post(self, request, id):
         if not request.user.is_authenticated:
-            return redirect("/login/?next=%s" % request.path)
+            return redirect(f"/login/?next={request.path}")
         video = Video.objects.get(id=id)
         if not allowed_to_edit(video, request.user):
             return HttpResponseForbidden(

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -175,7 +175,7 @@ class ManageVideoNew(AbstractVideoFormView):
             video = form.save()
             # Success, send to edit page
             return redirect("manage-video-edit", video.id)
-        return self.get(request, form=form, *args, **kwargs)
+        return self.get(request, *args, form=form, **kwargs)
 
 
 def allowed_to_edit(video, user):

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -5,22 +5,16 @@ import logging
 
 from django.conf import settings
 from django.core.paginator import Paginator
+from django.forms import ModelChoiceField, ModelForm
+from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
+from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.forms import ModelForm, ModelChoiceField
-from django.http import HttpResponseForbidden, HttpResponse, HttpRequest
-from django.shortcuts import redirect
-from django.shortcuts import render
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
-from fk.models import Organization
-from fk.models import Scheduleitem
-from fk.models import Video
-from fk.models import VideoFile
-from fk.models import WeeklySlot
-
+from fk.models import Organization, Scheduleitem, Video, VideoFile, WeeklySlot
 
 logger = logging.getLogger(__name__)
 

--- a/api/auth/permissions.py
+++ b/api/auth/permissions.py
@@ -39,7 +39,7 @@ class IsOrganizationEditorOrReadOnly(IsOrganizationEditorOrDisallow):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        return super(IsOrganizationEditorOrReadOnly, self).has_object_permission(request, view, obj)
+        return super().has_object_permission(request, view, obj)
 
 
 class IsInOrganizationOrDisallow(permissions.IsAuthenticatedOrReadOnly):
@@ -83,7 +83,7 @@ class IsInOrganizationOrReadOnly(IsInOrganizationOrDisallow):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        return super(IsInOrganizationOrReadOnly, self).has_object_permission(request, view, obj)
+        return super().has_object_permission(request, view, obj)
 
 
 class IsStaffOrReadOnly(permissions.BasePermission):

--- a/api/auth/serializers.py
+++ b/api/auth/serializers.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 
-from fk.models import User, Organization
+from fk.models import Organization, User
 
 
 class TokenSerializer(serializers.ModelSerializer):

--- a/api/auth/tests/permission_test.py
+++ b/api/auth/tests/permission_test.py
@@ -43,7 +43,7 @@ class PermissionsTest(APITestCase):
             self.assertEqual(
                 code,
                 page_response.status_code,
-                "{} status is {} expected {}".format(name, page_response.status_code, code),
+                f"{name} status is {page_response.status_code} expected {code}",
             )
 
     def _assert_permission_denied(self, res):

--- a/api/auth/tests/permission_test.py
+++ b/api/auth/tests/permission_test.py
@@ -36,7 +36,7 @@ class PermissionsTest(APITestCase):
         root_response = self.client.get(reverse("api-root"))
         self.assertEqual(status.HTTP_200_OK, root_response.status_code)
         # Every page exists
-        self.assertEqual(set(p[0] for p in pages), set(root_response.data.keys()))
+        self.assertEqual({p[0] for p in pages}, set(root_response.data.keys()))
         for name, code in pages:
             url = root_response.data[name]
             page_response = self.client.get(url)

--- a/api/auth/tests/permission_test.py
+++ b/api/auth/tests/permission_test.py
@@ -1,9 +1,8 @@
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase, APIClient
+from rest_framework.test import APIClient, APITestCase
 
 from fk.models import User
-
 
 PERMISSION_DENIED_DETAIL = "You do not have permission to perform this action."
 

--- a/api/auth/tests/test_user_profile.py
+++ b/api/auth/tests/test_user_profile.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase, APIRequestFactory, APIClient, force_authenticate
+from rest_framework.test import APIClient, APIRequestFactory, APITestCase, force_authenticate
 
 from api.auth.views import UserDetail
 from fk.models import User

--- a/api/auth/views.py
+++ b/api/auth/views.py
@@ -1,4 +1,4 @@
-from django.contrib.auth import login, logout, authenticate
+from django.contrib.auth import authenticate, login, logout
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
@@ -7,12 +7,12 @@ from rest_framework.authentication import BasicAuthentication
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
 from rest_framework.generics import CreateAPIView
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 
-from api.auth.serializers import TokenSerializer, NewUserSerializer, UserSerializer, LoginSerializer
+from api.auth.serializers import LoginSerializer, NewUserSerializer, TokenSerializer, UserSerializer
 
 
 class XBasicAuth(BasicAuthentication):

--- a/api/organization/serializers.py
+++ b/api/organization/serializers.py
@@ -1,3 +1,4 @@
+from phonenumber_field.phonenumber import PhoneNumber
 from rest_framework import serializers
 
 from api.serializers import logger
@@ -10,20 +11,23 @@ class OrganizationSerializer(serializers.ModelSerializer):
     editor_msisdn = serializers.SerializerMethodField()
     fkmember = serializers.BooleanField(read_only=True)
 
-    def get_editor_email(self, obj):
+    def get_editor_email(self, obj: Organization) -> str | None:
         if obj.editor:
             return obj.editor.email
         return None
 
-    def get_editor_msisdn(self, obj):
-        if obj.editor:
-            try:
-                return obj.editor.phone_number.as_international
-            except:
-                return ""
-        return None
+    def get_editor_msisdn(self, obj: Organization) -> str | None:
+        """The editor's number in international format, or None if there isn't one."""
+        if not obj.editor:
+            return None
+        number = obj.editor.phone_number
+        # phone_number is blank=True, so a blank value stays a plain str, and an
+        # unparseable one formats as the literal string "None".
+        if not isinstance(number, PhoneNumber) or not number.is_valid():
+            return None
+        return number.as_international
 
-    def get_editor_name(self, obj):
+    def get_editor_name(self, obj: Organization) -> str:
         if obj.editor:
             return obj.editor.first_name + " " + obj.editor.last_name
         logger.warning("Organization %d has no editor assigned", obj.id)

--- a/api/organization/tests/test_api.py
+++ b/api/organization/tests/test_api.py
@@ -5,7 +5,6 @@ from rest_framework.test import APIClient
 
 from fk.models import Organization, User
 
-
 pytestmark = pytest.mark.django_db
 
 

--- a/api/organization/tests/test_api.py
+++ b/api/organization/tests/test_api.py
@@ -28,9 +28,7 @@ def test_list_uses_model_ordering(editor: User) -> None:
     response = APIClient().get(reverse("api-organization-list"))
 
     assert response.status_code == status.HTTP_200_OK
-    assert result_ids(response) == [
-        organizations[name].pk for name in ("Alpha", "Middle", "Zulu")
-    ]
+    assert result_ids(response) == [organizations[name].pk for name in ("Alpha", "Middle", "Zulu")]
 
 
 def test_list_uses_default_pagination_limit(editor: User) -> None:
@@ -114,9 +112,7 @@ def test_create_requires_a_name(editor_client: APIClient) -> None:
 
 
 def test_anonymous_user_can_retrieve_an_organization(organization: Organization) -> None:
-    response = APIClient().get(
-        reverse("api-organization-detail", args=[organization.pk])
-    )
+    response = APIClient().get(reverse("api-organization-detail", args=[organization.pk]))
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data["id"] == organization.pk
@@ -169,9 +165,7 @@ def test_editor_can_delete_their_organization(
     editor_client: APIClient,
     organization: Organization,
 ) -> None:
-    response = editor_client.delete(
-        reverse("api-organization-detail", args=[organization.pk])
-    )
+    response = editor_client.delete(reverse("api-organization-detail", args=[organization.pk]))
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not Organization.objects.filter(pk=organization.pk).exists()

--- a/api/organization/tests/test_permissions.py
+++ b/api/organization/tests/test_permissions.py
@@ -5,7 +5,6 @@ from rest_framework.test import APIClient
 
 from fk.models import Organization, User
 
-
 pytestmark = pytest.mark.django_db
 
 

--- a/api/organization/tests/test_serializer.py
+++ b/api/organization/tests/test_serializer.py
@@ -27,12 +27,13 @@ def test_serializer_includes_organization_and_editor_details(
     }
 
 
-def test_serializer_handles_an_editor_without_a_phone_number(editor: User) -> None:
+@pytest.mark.parametrize("phone_number", ["", "not a number", "12345"])
+def test_serializer_reports_no_usable_phone_number_as_null(editor: User, phone_number: str) -> None:
     organization = Organization.objects.create(name="No phone", editor=editor)
-    editor.phone_number = ""
+    editor.phone_number = phone_number
     editor.save(update_fields=["phone_number"])
 
-    assert OrganizationSerializer(organization).data["editor_msisdn"] == ""
+    assert OrganizationSerializer(organization).data["editor_msisdn"] is None
 
 
 def test_serializer_handles_an_organization_without_an_editor(caplog) -> None:

--- a/api/organization/tests/test_serializer.py
+++ b/api/organization/tests/test_serializer.py
@@ -5,7 +5,6 @@ import pytest
 from api.organization.serializers import OrganizationSerializer
 from fk.models import Organization, User
 
-
 pytestmark = pytest.mark.django_db
 
 

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -1,7 +1,6 @@
 from rest_framework.pagination import LimitOffsetPagination
 
 
-
 class FkDefaultPagination(LimitOffsetPagination):
     default_limit = 50
     max_limit = 1000

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -5,5 +5,6 @@ class FkDefaultPagination(LimitOffsetPagination):
     default_limit = 50
     max_limit = 1000
 
+
 class FkSchedulePagination(FkDefaultPagination):
     default_limit = 200

--- a/api/schedule/query_set.py
+++ b/api/schedule/query_set.py
@@ -53,15 +53,11 @@ class ScheduleitemQuerySet(models.QuerySet):
         if not include_surrounding:
             return self.filter(main_filter).order_by("starttime")
 
-        previous_pk = (
-            self.filter(starttime__lt=start_dt).order_by("-starttime").values("pk")[:1]
-        )
+        previous_pk = self.filter(starttime__lt=start_dt).order_by("-starttime").values("pk")[:1]
         next_pk = self.filter(starttime__gte=end_dt).order_by("starttime").values("pk")[:1]
 
         return self.filter(
-            main_filter
-            | Q(pk__in=Subquery(previous_pk))
-            | Q(pk__in=Subquery(next_pk))
+            main_filter | Q(pk__in=Subquery(previous_pk)) | Q(pk__in=Subquery(next_pk))
         ).order_by("starttime")
 
     def expand_to_surrounding(

--- a/api/schedule/query_set.py
+++ b/api/schedule/query_set.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime, time, timedelta
-from typing import Union
 from zoneinfo import ZoneInfo
 
 from django.db import models
@@ -13,7 +12,7 @@ class ScheduleitemQuerySet(models.QuerySet):
 
     TZ = ZoneInfo("Europe/Oslo")
 
-    def normalize_date(self, value: Union[str, date, datetime, None]) -> date | None:
+    def normalize_date(self, value: str | date | datetime | None) -> date | None:
         """
         Normalize various date representations to a date object.
         Accepts strings in 'YYYY-MM-DD', date, datetime, or None.
@@ -33,7 +32,7 @@ class ScheduleitemQuerySet(models.QuerySet):
 
     def by_day(
         self,
-        start_date: Union[str, date, datetime, None] = None,
+        start_date: str | date | datetime | None = None,
         days: int = 7,
         include_surrounding: bool = False,
     ) -> models.QuerySet:

--- a/api/schedule/query_set.py
+++ b/api/schedule/query_set.py
@@ -25,7 +25,9 @@ class ScheduleitemQuerySet(models.QuerySet):
             return value.astimezone(self.TZ).date()
         if isinstance(value, str):
             try:
-                return datetime.strptime(value, "%Y-%m-%d").date()
+                # Date-only input, and only the date survives the call, so an
+                # absent zone cannot affect the result.
+                return datetime.strptime(value, "%Y-%m-%d").date()  # noqa: DTZ007
             except ValueError:
                 return None
         return None

--- a/api/schedule/serializers.py
+++ b/api/schedule/serializers.py
@@ -1,7 +1,8 @@
 from zoneinfo import ZoneInfo
+
 from rest_framework import serializers
 
-from fk.models import Category, Video, Scheduleitem, AsRun, Organization, VideoFile
+from fk.models import AsRun, Category, Organization, Scheduleitem, Video, VideoFile
 
 
 class ScheduleitemVideoFileSerializer(serializers.ModelSerializer):

--- a/api/schedule/serializers.py
+++ b/api/schedule/serializers.py
@@ -68,7 +68,7 @@ class ScheduleitemModifySerializer(serializers.ModelSerializer):
             )
             for entry in items:
                 if entry.starttime < end and start < entry.endtime():
-                    raise serializers.ValidationError({"duration": "Conflict with '%s'." % entry})
+                    raise serializers.ValidationError({"duration": f"Conflict with '{entry}'."})
         return data
 
 

--- a/api/schedule/tests/test_api.py
+++ b/api/schedule/tests/test_api.py
@@ -11,7 +11,6 @@ from rest_framework.test import APIClient
 
 from fk.models import Scheduleitem, Video
 
-
 pytestmark = pytest.mark.django_db
 
 OSLO = ZoneInfo("Europe/Oslo")

--- a/api/schedule/tests/test_detail_api.py
+++ b/api/schedule/tests/test_detail_api.py
@@ -20,9 +20,7 @@ def test_retrieve_schedule_item_ignores_list_date_window(
 ) -> None:
     item = schedule_item_factory(starttime=HISTORICAL_START)
 
-    response = authenticated_client.get(
-        reverse("api-scheduleitem-detail", args=[item.pk])
-    )
+    response = authenticated_client.get(reverse("api-scheduleitem-detail", args=[item.pk]))
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data["id"] == item.pk
@@ -34,9 +32,7 @@ def test_delete_schedule_item_ignores_list_date_window(
 ) -> None:
     item = schedule_item_factory(starttime=HISTORICAL_START)
 
-    response = authenticated_client.delete(
-        reverse("api-scheduleitem-detail", args=[item.pk])
-    )
+    response = authenticated_client.delete(reverse("api-scheduleitem-detail", args=[item.pk]))
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not Scheduleitem.objects.filter(pk=item.pk).exists()

--- a/api/schedule/tests/test_detail_api.py
+++ b/api/schedule/tests/test_detail_api.py
@@ -9,7 +9,6 @@ from rest_framework.test import APIClient
 
 from fk.models import Scheduleitem
 
-
 pytestmark = pytest.mark.django_db
 
 HISTORICAL_START = datetime(2015, 1, 1, 10, tzinfo=ZoneInfo("Europe/Oslo"))

--- a/api/schedule/tests/test_list_api.py
+++ b/api/schedule/tests/test_list_api.py
@@ -171,9 +171,7 @@ def test_surrounding_tolerates_missing_neighbors(
     target_day = date(2015, 1, 2)
     expected = []
     if has_previous:
-        expected.append(
-            schedule_item_factory(starttime=at(target_day - timedelta(days=1), 23))
-        )
+        expected.append(schedule_item_factory(starttime=at(target_day - timedelta(days=1), 23)))
     expected.append(schedule_item_factory(starttime=at(target_day, 10)))
     if has_next:
         expected.append(schedule_item_factory(starttime=at(target_day + timedelta(days=1))))
@@ -201,9 +199,7 @@ def test_list_orders_by_starttime(
     expected_indexes: list[int],
 ) -> None:
     target_day = date(2015, 1, 2)
-    items = [
-        schedule_item_factory(starttime=at(target_day, hour)) for hour in (9, 10, 11)
-    ]
+    items = [schedule_item_factory(starttime=at(target_day, hour)) for hour in (9, 10, 11)]
 
     response = authenticated_client.get(
         reverse("api-scheduleitem-list"),

--- a/api/schedule/tests/test_list_api.py
+++ b/api/schedule/tests/test_list_api.py
@@ -11,7 +11,6 @@ from rest_framework.test import APIClient
 
 from fk.models import Category, FileFormat, Scheduleitem, Video, VideoFile
 
-
 pytestmark = pytest.mark.django_db
 
 OSLO = ZoneInfo("Europe/Oslo")

--- a/api/schedule/tests/test_permissions.py
+++ b/api/schedule/tests/test_permissions.py
@@ -10,7 +10,6 @@ from rest_framework.test import APIClient
 
 from fk.models import Organization, Scheduleitem, User, Video
 
-
 pytestmark = pytest.mark.django_db
 
 OSLO = ZoneInfo("Europe/Oslo")

--- a/api/schedule/tests/test_query_set.py
+++ b/api/schedule/tests/test_query_set.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -16,7 +16,7 @@ OSLO = ZoneInfo("Europe/Oslo")
     ("value", "expected"),
     [
         pytest.param(
-            datetime(2015, 1, 1, 23, 30, tzinfo=timezone.utc),
+            datetime(2015, 1, 1, 23, 30, tzinfo=UTC),
             date(2015, 1, 2),
             id="timezone-aware-datetime",
         ),

--- a/api/schedule/tests/test_query_set.py
+++ b/api/schedule/tests/test_query_set.py
@@ -7,7 +7,6 @@ from django.utils import timezone as django_timezone
 
 from fk.models import Scheduleitem
 
-
 pytestmark = pytest.mark.django_db
 
 OSLO = ZoneInfo("Europe/Oslo")

--- a/api/schedule/views.py
+++ b/api/schedule/views.py
@@ -2,9 +2,9 @@ from django.db.models import Prefetch
 from rest_framework import viewsets
 
 from api.auth.permissions import IsInOrganizationOrReadOnly
+from api.pagination import FkSchedulePagination
 from api.schedule.filters import ScheduleitemFilter
 from api.schedule.serializers import ScheduleitemModifySerializer, ScheduleitemReadSerializer
-from api.pagination import FkSchedulePagination
 from fk.models import Scheduleitem, VideoFile
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2012-2013 Benjamin Bruheim <grolgh@gmail.com>
 # This file is covered by the LGPLv3 or later, read COPYING for details.
 
-from rest_framework import serializers
-
 import logging
 
-from fk.models import Category
-from fk.models import Video
+from rest_framework import serializers
+
+from fk.models import Category, Video
 
 logger = logging.getLogger(__name__)
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase, APIClient
+from rest_framework.test import APIClient, APITestCase
 
 
 class FilterTest(APITestCase):

--- a/api/tests.py
+++ b/api/tests.py
@@ -16,11 +16,11 @@ class FilterTest(APITestCase):
             url = reverse(urlname) + lookup
             r = self.client.get(url)
             self.assertEqual(
-                status.HTTP_200_OK, r.status_code, "lookup '%s' did not return status 200" % url
+                status.HTTP_200_OK, r.status_code, f"lookup '{url}' did not return status 200"
             )
             videos = [v[fieldname] for v in r.data["results"]]
             self.assertEqual(
-                expect, videos, "%s lookup '%s' expect %s got %s" % (urlname, url, expect, videos)
+                expect, videos, f"{urlname} lookup '{url}' expect {expect} got {videos}"
             )
 
     def test_can_filter_video(self):

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,21 +1,21 @@
 # Copyright (c) 2012-2013 Benjamin Bruheim <grolgh@gmail.com>
 # This file is covered by the LGPLv3 or later, read COPYING for details.
-from django.urls import re_path as url
 from django.urls import include, path
+from django.urls import re_path as url
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from rest_framework import parsers
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.routers import SimpleRouter
 from rest_framework.urlpatterns import format_suffix_patterns
-from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 import api.auth.views
 import api.organization.views
+import api.schedule.views as schedule_views
 import api.video.views
 import api.videofile.views as videofile_views
-import api.schedule.views as schedule_views
 from fkweb.views import CsrfView
-from . import views
 
+from . import views
 
 router = SimpleRouter()
 router.register(r"api/asrun", views.AsRunViewSet, "asrun")

--- a/api/video/serializers.py
+++ b/api/video/serializers.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
 from api.organization.serializers import OrganizationSerializer
-from fk.models import Category, Video, Organization
+from fk.models import Category, Organization, Video
 
 
 class VideoSerializer(serializers.ModelSerializer):

--- a/api/video/views.py
+++ b/api/video/views.py
@@ -148,6 +148,6 @@ class VideoList(generics.ListCreateAPIView):
         if proper_import and "false" == proper_import:
             queryset = Video.objects.all()
         else:
-            queryset = super(VideoList, self).get_queryset()
+            queryset = super().get_queryset()
 
         return queryset

--- a/api/video/views.py
+++ b/api/video/views.py
@@ -2,10 +2,10 @@ from django.db.models import Q
 from django_filters import rest_framework as djfilters
 from rest_framework import generics
 
-from api.auth.permissions import IsInOrganizationOrReadOnly, IsInOrganizationOrDisallow
-from api.video.serializers import VideoSerializer, VideoCreateSerializer, VideoUploadTokenSerializer
+from api.auth.permissions import IsInOrganizationOrDisallow, IsInOrganizationOrReadOnly
 from api.pagination import FkDefaultPagination
-from fk.models import Video, Category
+from api.video.serializers import VideoCreateSerializer, VideoSerializer, VideoUploadTokenSerializer
+from fk.models import Category, Video
 
 
 class VideoDetail(generics.RetrieveUpdateDestroyAPIView):

--- a/api/videofile/serializers.py
+++ b/api/videofile/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework.serializers import ModelSerializer, PrimaryKeyRelatedField
 
-from fk.models import VideoFile, Video, FileFormat
+from fk.models import FileFormat, Video, VideoFile
 
 
 class VideoFileSerializer(ModelSerializer):

--- a/api/videofile/views.py
+++ b/api/videofile/views.py
@@ -1,12 +1,10 @@
 from django_filters import rest_framework as djfilters
+from rest_framework import viewsets
 
 from api.auth.permissions import IsInOrganizationOrReadOnly
-from api.videofile.serializers import VideoFileSerializer
 from api.pagination import FkDefaultPagination
+from api.videofile.serializers import VideoFileSerializer
 from fk.models import VideoFile
-
-
-from rest_framework import viewsets
 
 
 class VideoFileFilter(djfilters.FilterSet):

--- a/api/views.py
+++ b/api/views.py
@@ -45,8 +45,17 @@ def jukebox_csv(request):
     response = HttpResponse(content_type="text/csv; charset=utf-8")
     response["Content-Disposition"] = "filename=jukebox.csv"
     fields = (
-        "id|name|has_tono_records|video_id|type_id|version|"
-        "creation_began|creation_finished|offset|duration|location".split("|")
+        "id",
+        "name",
+        "has_tono_records",
+        "video_id",
+        "type_id",
+        "version",
+        "creation_began",
+        "creation_finished",
+        "offset",
+        "duration",
+        "location",
     )
     writer = csv.DictWriter(response, fields, delimiter="|")
     writer.writeheader()

--- a/api/views.py
+++ b/api/views.py
@@ -3,20 +3,18 @@
 
 import csv
 import logging
+
 from django.http import HttpResponse
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
-from rest_framework.viewsets import ModelViewSet
 from rest_framework.reverse import reverse
-from api.pagination import FkDefaultPagination
-from fk.models import AsRun
-from fk.models import Category
-from fk.models import Video
-from fk.models import VideoFile
+from rest_framework.viewsets import ModelViewSet
 
 from api.auth.permissions import IsStaffOrReadOnly
+from api.pagination import FkDefaultPagination
 from api.schedule.serializers import AsRunSerializer
 from api.serializers import CategorySerializer
+from fk.models import AsRun, Category, Video, VideoFile
 
 logger = logging.getLogger(__name__)
 

--- a/api/views.py
+++ b/api/views.py
@@ -66,21 +66,23 @@ def jukebox_csv(request):
             videofile = video.videofile_set.get(format__fsname="broadcast")
         except VideoFile.DoesNotExist:
             continue
+        # NB: this is bytes, so it interpolates below as b'...'. Kept verbatim
+        # to leave this endpoint's long-standing output untouched.
+        encoded_filename = videofile.filename.encode("utf-8")
         writer.writerow(
-            dict(
-                id=video.id,
-                name=video.name.encode("utf-8"),
-                has_tono_records={False: "f", True: "t"}[video.has_tono_records],
-                video_id=video.id,
-                type_id=videofile.format.id,
-                version=1,  # What is this for?
-                creation_began=video.created_time,  # ??
-                creation_finished=None,  # ??
-                offset=0,
-                duration=video.duration.total_seconds(),
-                location="http://frontend.frikanalen.tv/media/%s"
-                % (videofile.filename.encode("utf-8")),
-            )
+            {
+                "id": video.id,
+                "name": video.name.encode("utf-8"),
+                "has_tono_records": {False: "f", True: "t"}[video.has_tono_records],
+                "video_id": video.id,
+                "type_id": videofile.format.id,
+                "version": 1,  # What is this for?
+                "creation_began": video.created_time,  # ??
+                "creation_finished": None,  # ??
+                "offset": 0,
+                "duration": video.duration.total_seconds(),
+                "location": f"http://frontend.frikanalen.tv/media/{encoded_filename}",
+            }
         )
     return response
 

--- a/fk/admin.py
+++ b/fk/admin.py
@@ -4,17 +4,18 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import Group
 
-from fk.forms import UserChangeForm
-from fk.forms import UserCreationForm
-from fk.models import Category
-from fk.models import FileFormat
-from fk.models import Organization
-from fk.models import SchedulePurpose
-from fk.models import Scheduleitem
-from fk.models import User
-from fk.models import Video
-from fk.models import VideoFile
-from fk.models import WeeklySlot
+from fk.forms import UserChangeForm, UserCreationForm
+from fk.models import (
+    Category,
+    FileFormat,
+    Organization,
+    Scheduleitem,
+    SchedulePurpose,
+    User,
+    Video,
+    VideoFile,
+    WeeklySlot,
+)
 
 
 class UserAdmin(BaseUserAdmin):

--- a/fk/forms.py
+++ b/fk/forms.py
@@ -1,7 +1,5 @@
 from django import forms
-from django.contrib.auth import forms as auth_forms
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
-from django.db import models
 
 from fk.models import User
 

--- a/fk/forms.py
+++ b/fk/forms.py
@@ -5,8 +5,6 @@ from fk.models import User
 
 
 class UserForm(forms.ModelForm):
-    pass
-
     class Meta:
         model = User
         fields = ["first_name", "last_name", "phone_number"]

--- a/fk/models/__init__.py
+++ b/fk/models/__init__.py
@@ -10,13 +10,13 @@ transferred.
 
 import logging
 
+from .asrun import AsRun  # noqa: F401
 from .category import Category  # noqa: F401
+from .ingest import Asset, IngestJob  # noqa: F401
+from .organization import Organization  # noqa: F401
+from .schedule import Scheduleitem, SchedulePurpose, WeeklySlot  # noqa: F401
 from .user import User, UserManager  # noqa: F401
 from .video import Video  # noqa: F401
 from .video_file import FileFormat, VideoFile  # noqa: F401
-from .schedule import Scheduleitem, SchedulePurpose, WeeklySlot  # noqa: F401
-from .organization import Organization  # noqa: F401
-from .asrun import AsRun  # noqa: F401
-from .ingest import IngestJob, Asset  # noqa: F401
 
 logger = logging.getLogger(__name__)

--- a/fk/models/asrun.py
+++ b/fk/models/asrun.py
@@ -46,8 +46,8 @@ class AsRun(TimeStampedModel):
 
     def __str__(self):
         if self.video:
-            return "{s.playout} video: {s.video}".format(s=self)
-        return "{s.playout}: {s.program_name}".format(s=self)
+            return f"{self.playout} video: {self.video}"
+        return f"{self.playout}: {self.program_name}"
 
     class Meta:
         ordering = (

--- a/fk/models/ingest.py
+++ b/fk/models/ingest.py
@@ -1,6 +1,5 @@
 from django.db import models
 
-
 # This class is actually not managed by Django. It is accessed by the
 # media-processor, which manipulates the database directly. It is only
 # defined here so that database migrations are handled centrally.

--- a/fk/models/schedule.py
+++ b/fk/models/schedule.py
@@ -166,4 +166,4 @@ class WeeklySlot(models.Model):
         return timezone.make_aware(datetime.combine(next_date, self.start_time))
 
     def __str__(self):
-        return "{day} {s.start_time} ({s.purpose})".format(day=self.get_day_display(), s=self)
+        return f"{self.get_day_display()} {self.start_time} ({self.purpose})"

--- a/fk/models/schedule.py
+++ b/fk/models/schedule.py
@@ -37,14 +37,9 @@ class Scheduleitem(models.Model):
         ordering = ("-id",)
 
     def __str__(self):
-        t = self.starttime
-        s = t.strftime("%Y-%m-%d %H:%M:%S")
-        # format microsecond to hundreths
-        s += ".%02i" % (t.microsecond / 10000)
-        if self.video:
-            return str(s) + ": " + str(self.video)
-        else:
-            return str(s) + ": " + self.default_name
+        # %f renders microseconds as six digits; drop four to get hundredths
+        timestamp = self.starttime.strftime("%Y-%m-%d %H:%M:%S.%f")[:-4]
+        return f"{timestamp}: {self.video or self.default_name}"
 
     def endtime(self):
         if not self.duration:

--- a/fk/models/schedule.py
+++ b/fk/models/schedule.py
@@ -142,14 +142,16 @@ class WeeklySlot(models.Model):
         if not self.duration:
             return self.start_time
 
-        # make a mock date so we can do timedelta arithmetic
-        dummy_date = datetime.combine(date.today(), self.start_time)
+        # any fixed date will do; only the time survives the arithmetic
+        dummy_date = datetime.combine(date(1970, 1, 1), self.start_time)
         end_datetime = dummy_date + self.duration
         return end_datetime.time()
 
     def next_date(self, from_date=None):
         if not from_date:
-            from_date = date.today()
+            # next_datetime() combines this with make_aware(), which resolves
+            # against Django's timezone, so the date has to come from there too
+            from_date = timezone.localdate()
         days_ahead = self.day - from_date.weekday()
         if days_ahead <= 0:
             # target date already happened this week

--- a/fk/models/schedule.py
+++ b/fk/models/schedule.py
@@ -86,7 +86,7 @@ class SchedulePurpose(models.Model):
         elif self.type == self.TYPE.videos:
             qs = self.direct_videos.all()
         else:
-            raise Exception("Unhandled type %s" % self.type)
+            raise ValueError(f"Unhandled type {self.type}")
         if max_duration:
             qs = qs.filter(duration__lte=max_duration)
         # Workaround playout not handling broken files correctly
@@ -110,7 +110,7 @@ class SchedulePurpose(models.Model):
             # Get the video which has been scheduled the least
             return qs.annotate(num_sched=models.Count("scheduleitem")).order_by("num_sched").first()
         else:
-            raise Exception("Unhandled strategy %s" % self.strategy)
+            raise ValueError(f"Unhandled strategy {self.strategy}")
 
     def __str__(self):
         return self.name

--- a/fk/models/schedule.py
+++ b/fk/models/schedule.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from model_utils import Choices
+
 from api.schedule.query_set import ScheduleitemQuerySet
 
 

--- a/fk/models/user.py
+++ b/fk/models/user.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.base_user import BaseUserManager, AbstractBaseUser
+from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext as _

--- a/fk/models/video.py
+++ b/fk/models/video.py
@@ -9,13 +9,11 @@ from django.db import models
 
 class VideoManager(models.Manager):
     def public(self):
-        return (
-            super(VideoManager, self).get_queryset().filter(publish_on_web=True, proper_import=True)
-        )
+        return super().get_queryset().filter(publish_on_web=True, proper_import=True)
 
     def fillers(self):
         return (
-            super(VideoManager, self)
+            super()
             .get_queryset()
             .filter(
                 is_filler=True,

--- a/fk/models/video_file.py
+++ b/fk/models/video_file.py
@@ -65,7 +65,7 @@ class VideoFile(models.Model):
         )
 
     def __str__(self):
-        return "%s version of %s" % (self.format.fsname, self.video.name)
+        return f"{self.format.fsname} version of {self.video.name}"
 
     def location(self, relative=False):
         filename = os.path.basename(self.filename)
@@ -75,4 +75,4 @@ class VideoFile(models.Model):
         if relative:
             return path
         else:
-            return "/".join((settings.FK_MEDIA_ROOT, path))
+            return f"{settings.FK_MEDIA_ROOT}/{path}"

--- a/fk/models/video_file.py
+++ b/fk/models/video_file.py
@@ -3,7 +3,6 @@ import os
 from django.conf import settings
 from django.db import models
 
-
 # we are slowly getting these out of the database, but can't make schema changes
 # until we have migrated away from the old version of Django.
 FILE_FORMATS = [

--- a/fk/templatetags/fk_utils.py
+++ b/fk/templatetags/fk_utils.py
@@ -3,7 +3,6 @@ import math
 
 from django import template
 
-
 register = template.Library()
 
 

--- a/fkweb/middleware.py
+++ b/fkweb/middleware.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 def api_utc_middleware(get_response):
     def middleware(request):
         is_api = request.path.startswith("/api/")
-        with timezone.override(datetime.timezone.utc if is_api else None):
+        with timezone.override(datetime.UTC if is_api else None):
             return get_response(request)
 
     return middleware

--- a/fkweb/middleware.py
+++ b/fkweb/middleware.py
@@ -1,5 +1,6 @@
-from django.utils import timezone
 import datetime
+
+from django.utils import timezone
 
 
 def api_utc_middleware(get_response):

--- a/fkweb/settings/base.py
+++ b/fkweb/settings/base.py
@@ -7,8 +7,8 @@
 """Common settings and globals."""
 
 import logging
-from os.path import abspath, basename, dirname, join, normpath
 import sys
+from os.path import abspath, basename, dirname, join, normpath
 
 from environ import ImproperlyConfigured
 

--- a/fkweb/settings/base.py
+++ b/fkweb/settings/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim: ts=4 sts=4 expandtab ai
 
 # Copyright (c) 2012-2013 Benjamin Bruheim <grolgh@gmail.com>

--- a/fkweb/settings/base.py
+++ b/fkweb/settings/base.py
@@ -13,6 +13,8 @@ from environ import ImproperlyConfigured
 
 from .env import env, load_env_from
 
+logger = logging.getLogger(__name__)
+
 load_env_from(".env")
 
 
@@ -364,8 +366,8 @@ DATABASES = {"default": env.db()}
 CSRF_TRUSTED_ORIGINS = env.str("CSRF_TRUSTED_ORIGINS").split(",")
 try:
     cache_from_env_or_memory = env.cache()
-except ImproperlyConfigured:  # noqa: F821
-    logging.warning("CACHE_URL not set, falling back to in-memory cache.")
+except ImproperlyConfigured:
+    logger.warning("CACHE_URL not set, falling back to in-memory cache.")
     cache_from_env_or_memory = {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
 
 CACHES = {"default": cache_from_env_or_memory}

--- a/fkweb/settings/base.py
+++ b/fkweb/settings/base.py
@@ -188,7 +188,7 @@ MIDDLEWARE = (
 
 ########## URL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#root-urlconf
-ROOT_URLCONF = "%s.urls" % SITE_NAME
+ROOT_URLCONF = f"{SITE_NAME}.urls"
 ########## END URL CONFIGURATION
 
 
@@ -282,7 +282,7 @@ LOGGING = {
 
 ########## WSGI CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#wsgi-application
-WSGI_APPLICATION = "%s.wsgi.application" % SITE_NAME
+WSGI_APPLICATION = f"{SITE_NAME}.wsgi.application"
 ########## END WSGI CONFIGURATION
 
 ########## REST FRAMEWORK CONFIGURATION

--- a/fkweb/settings/env.py
+++ b/fkweb/settings/env.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import environ
 
+logger = logging.getLogger(__name__)
+
 
 def find_project_root() -> Path:
     marker = "manage.py"
@@ -17,7 +19,7 @@ def find_project_root() -> Path:
 def load_env_from(file: str) -> None:
     """Load environment variables from a specified file."""
     environ.Env.read_env(str(find_project_root() / file))
-    logging.info(f"Loading environment from {file}")
+    logger.info("Loading environment from %s", file)
 
 
 env = environ.Env(

--- a/fkweb/settings/env.py
+++ b/fkweb/settings/env.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 import logging
+from pathlib import Path
+
 import environ
 
 

--- a/fkweb/signals.py
+++ b/fkweb/signals.py
@@ -1,4 +1,4 @@
-def create_auth_token(sender=None, instance=None, created=False, **_kwargs):  # noqa: ARG001
+def create_auth_token(sender=None, instance=None, created=False, **_kwargs):
     from rest_framework.authtoken.models import Token
 
     """Create a new token for every new user, this is needed for auth to the API"""

--- a/fkweb/urls.py
+++ b/fkweb/urls.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2012-2013 Benjamin Bruheim <grolgh@gmail.com>
 # This file is covered by the LGPLv3 or later, read COPYING for details.
 

--- a/fkweb/urls.py
+++ b/fkweb/urls.py
@@ -3,14 +3,13 @@
 # This file is covered by the LGPLv3 or later, read COPYING for details.
 
 from django.conf.urls import include
-from django.urls import re_path as url
 from django.contrib import admin
 from django.contrib.auth.views import LoginView, LogoutView
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import re_path as url
 
 import agenda.urls
 import api.urls
-import news.urls
 from fkweb.views import Frontpage
 
 admin.autodiscover()

--- a/fkweb/views.py
+++ b/fkweb/views.py
@@ -13,7 +13,7 @@ class Frontpage(TemplateView):
     template_name = "frontpage.html"
 
     def get_context_data(self, *args, **kwargs):
-        context = super(Frontpage, self).get_context_data(*args, **kwargs)
+        context = super().get_context_data(*args, **kwargs)
         context["title"] = _("TV for alle")
         try:
             current, prev = Scheduleitem.objects.filter(starttime__lt=timezone.now()).order_by(

--- a/news/serializers.py
+++ b/news/serializers.py
@@ -1,5 +1,6 @@
-from .models import Bulletin
 from rest_framework import serializers
+
+from .models import Bulletin
 
 
 class BulletinSerializer(serializers.HyperlinkedModelSerializer):

--- a/news/tests.py
+++ b/news/tests.py
@@ -37,7 +37,7 @@ class TestArticleList(TestCase):
                 s = insert_into_string(s, i, punct)
             return s.strip().capitalize()
 
-        for n in range(0, 50):
+        for n in range(50):
             heading = random_string(30)
             text = random_string(300)
             Bulletin.objects.create(heading=heading, text=text)

--- a/news/tests.py
+++ b/news/tests.py
@@ -1,10 +1,9 @@
-import string
 import random
+import string
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from rest_framework.test import APIRequestFactory
-from rest_framework.test import force_authenticate
+from rest_framework.test import APIRequestFactory, force_authenticate
 
 from .models import Bulletin
 from .views import BulletinViewSet

--- a/news/urls.py
+++ b/news/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path
 from rest_framework import routers
+
 from .views import BulletinViewSet
 
 router = routers.DefaultRouter()

--- a/news/views.py
+++ b/news/views.py
@@ -1,8 +1,9 @@
-from .models import Bulletin
-from .serializers import BulletinSerializer
+from rest_framework import viewsets
+
 from api.auth.permissions import IsStaffOrReadOnly
 
-from rest_framework import viewsets
+from .models import Bulletin
+from .serializers import BulletinSerializer
 
 
 class BulletinViewSet(viewsets.ModelViewSet):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,26 @@ dependencies = [
 
 [tool.ruff]
 line-length = 100
+exclude = [
+    # Vendored third-party type stubs. Copies of upstream sources, not our code:
+    # linting or reformatting them only makes the next refresh harder to diff.
+    "typings",
+    # Migrations are archival. They record what was applied to the database and
+    # are never edited after the fact, so the linter has no business in them.
+    "*/migrations",
+]
+# Without this, `ruff check fk/migrations` (or a pre-commit hook passing
+# filenames) would lint the excluded paths anyway.
+force-exclude = true
+
+[tool.ruff.lint]
+ignore = [
+    # Django and DRF are declarative: `fields`, `permission_classes` and
+    # `list_display` are all mutable class attributes by design, and the
+    # frameworks read them off the class. Every occurrence in this codebase is
+    # one of those, so the rule only buys us `ClassVar` noise on ~25 lines.
+    "RUF012",
+]
 
 [tool.pytest]
 minversion = "9.1"


### PR DESCRIPTION
Resolves the TODO in `django-api.yml` that deferred a `lint` job until the
codebase could pass one. `ruff check` and `ruff format --check` are now clean,
and both run in CI.

The ten commits go from mechanical to substantive, so review can start at the
bottom and stop wherever it stops being interesting.

## Scoping the linter

Ruff 0.16's default rule set turned up 235 findings. Three groups were noise
rather than defects, and excluding them first took that to 104:

- **`typings/`** holds vendored upstream stubs. Reformatting them only makes the
  next refresh harder to diff.
- **Migrations are archival.** They record what was applied to the database and
  are not edited afterwards. `force-exclude` keeps this honest when paths are
  passed explicitly, as a pre-commit hook would. `git diff main..HEAD --
  '*/migrations/*'` is empty.
- **`RUF012`** fires on Django and DRF declarative attributes (`fields`,
  `permission_classes`, `list_display`). All ~25 occurrences are framework
  convention.

## Bugs found along the way

None of these were the point of the exercise, and all three are covered by the
commit messages in detail:

- **`logger.debug("end overshoots time", ...)`** passed an argument with no
  placeholder, so `logging` raised internally and swallowed it. That diagnostic
  has never printed.
- **`WeeklySlot.next_date()`** defaulted to `date.today()` — the container's UTC
  clock — while `next_datetime()` combines that date with `make_aware()`, which
  resolves against `TIME_ZONE = Europe/Oslo`. They disagree for an hour or two
  after Norwegian midnight, and because `next_date()` rounds a non-positive
  weekday delta up by seven days, a one-day slip becomes a **seven-day** slip.
  `fill_next_weeks_agenda` runs as a management command in local time.
- **`editor_msisdn`** emitted the literal string `"None"` for an unparseable
  number. `format_number()` renders one that way and never raises, so the bare
  `except` never saw it.

## Behaviour changes to weigh

- **`editor_msisdn` nullability** (`fix(api)`). Returned `""` for a blank number
  but `null` for a missing editor; both are `null` now. Gating on `is_valid()`
  also rejects well-formed numbers outside a real range — `+4712345678` becomes
  `null` where it used to render. Real Norwegian editor numbers pass.
- **`next_date()`** now derives from Django's timezone rather than the OS clock.
- **`build` gains `lint` as a prerequisite,** so a red linter blocks the release
  image. This is more than the TODO asked for; happy to drop back to
  `needs: test` if you'd rather lint stayed advisory. `uv.lock` pins ruff, so the
  rule set only moves on a deliberate bump.

## Deliberately left alone

`jukebox_csv` interpolates `bytes`, so `location` and `name` render as `b'...'`
in the CSV. Preserved byte-identically with a comment — it is an external
contract and deserves its own decision rather than riding along with a
formatting pass.

## Verification

`ruff check`, `ruff format --check` and the full suite (119 tests, 2 new) pass at
`HEAD`. Equivalence was checked directly where a rewrite could have changed
output: `Scheduleitem.__str__` over the full microsecond range, the `jukebox_csv`
field list, `csv.DictWriter` with a tuple, and `make_aware`'s default timezone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
