### PR TITLE
Weighted jukebox selection and the broadcast-week lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,19 +102,19 @@ uv run pytest --cov
 
 ## Management commands
 
-In addition to the HTTP API, the following commands are executed periodically as Kubernetes cron jobs in our cluster:
+In addition to the HTTP API, the following commands are executed periodically as Kubernetes cron jobs in our cluster. Together they implement the broadcast-week lifecycle defined in `agenda/scheduling/policy.py`: every week is drafted two Mondays before it airs, stays open for member organizations to replace jukebox fillers with picks of their own for one week, and is frozen from the Monday before airing.
 
 ```sh
 ./manage.py fill_next_weeks_agenda
 ```
 
-This job will fill the next week's schedule with videos as defined by the WeeklySlot model. This will generally be entries like "Fill Mondays 12-13 with the latest videos from NUUG".
+This job places videos as defined by the WeeklySlot model, for every slot occurrence up to the end of the open broadcast week. This will generally be entries like "Fill Mondays 12-13 with the latest videos from NUUG".
 
 ```sh
 ./manage.py fill_agenda_with_jukebox
 ```
 
-This job will fill the remaining unpopulated areas with videos as randomly selected from the set of all videos marked with is_filler=True.
+This job fills the remaining unpopulated airtime up to the end of the open broadcast week, drawing from the videos marked with is_filler=True by a weighted-random draw that prefers fresh uploads and organizations with little airtime that week (see `agenda/scheduling/selection.py`).
 
 ## Test data
 

--- a/agenda/management/commands/fill_agenda_with_jukebox.py
+++ b/agenda/management/commands/fill_agenda_with_jukebox.py
@@ -5,11 +5,11 @@ from agenda.scheduling.jukebox import fill_agenda_with_jukebox
 
 class Command(BaseCommand):
     args = ""
-    help = "Automatically fill all available time with jukebox"
+    help = "Fill empty airtime with jukebox fillers through the end of the open broadcast week"
 
     def handle(self, *args, **options):
         if 1 < int(options["verbosity"]):
             import logging
 
             logging.basicConfig(level=logging.INFO)
-        fill_agenda_with_jukebox(days=2)
+        fill_agenda_with_jukebox()

--- a/agenda/scheduling/__init__.py
+++ b/agenda/scheduling/__init__.py
@@ -6,9 +6,14 @@ Neither half of this runs on the web request path; both are invoked from
 management commands, and thus from the nightly CronJobs, in this order:
 
 1. :mod:`~agenda.scheduling.weekly_slots` places one video per WeeklySlot.
-2. :mod:`~agenda.scheduling.jukebox` fills the airtime those slots leave over.
+2. :mod:`~agenda.scheduling.jukebox` fills the airtime those slots leave over,
+   choosing fillers by the weighted rules in
+   :mod:`~agenda.scheduling.selection` -- which see the slots' placements,
+   so an organization the slots favor gets its fillers downplayed.
 
-They share no code -- they disagree, in particular, about what counts as
-airtime already taken. Import the entry point you want from its own module
-rather than from this package, so it stays obvious which half you are calling.
+The two entry points still disagree about what counts as airtime already
+taken (the slot filler asks ``overlapping()``, the jukebox walks the
+window minute-aligned). Import the entry point you want from its own
+module rather than from this package, so it stays obvious which half you
+are calling.
 """

--- a/agenda/scheduling/__init__.py
+++ b/agenda/scheduling/__init__.py
@@ -2,6 +2,11 @@
 # This file is covered by the LGPLv3 or later, read COPYING for details.
 """Filling the broadcast schedule.
 
+When and how far ahead any of this happens is
+:mod:`~agenda.scheduling.policy`'s single say: weeks are drafted two
+Mondays before they air, open to member picks for one week, and frozen
+from the Monday before airing.
+
 Neither half of this runs on the web request path; both are invoked from
 management commands, and thus from the nightly CronJobs, in this order:
 

--- a/agenda/scheduling/jukebox.py
+++ b/agenda/scheduling/jukebox.py
@@ -51,16 +51,33 @@ def fill_agenda_with_jukebox(start=None, days=None, rng=None):
     selector = WeightedSelector(candidates, context, default_rules(now=start), rng=rng)
 
     placements = items_for_gap(start, end, candidates, selector=selector)
+    return save_placements(placements)
+
+
+def save_placements(placements: list["Placement"]) -> list["Placement"]:
+    """Persist planned placements; returns the ones actually saved.
+
+    Airtime that was free at planning time can have been taken since --
+    a member pick landing while the nightly run walks its two-week
+    window -- and there is no database exclusion constraint yet to
+    catch that, so each placement re-checks just before writing. A
+    taken slot is skipped, not fought over: whatever landed there was
+    more deliberate than filler.
+    """
+    saved = []
     for placement in placements:
-        item = Scheduleitem(
+        end = placement.starttime + placement.video.duration
+        if Scheduleitem.objects.overlapping(placement.starttime, end).exists():
+            logger.info("Airtime at %s was taken since planning; skipping", placement.starttime)
+            continue
+        Scheduleitem.objects.create(
             video=placement.video,
             schedulereason=Scheduleitem.REASON_JUKEBOX,
             starttime=placement.starttime,
             duration=placement.video.duration,
         )
-        item.save()
-
-    return placements
+        saved.append(placement)
+    return saved
 
 
 def next_whole_minute(dt):

--- a/agenda/scheduling/jukebox.py
+++ b/agenda/scheduling/jukebox.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 
 from django.utils import timezone
 
+from agenda.scheduling.policy import scheduling_horizon
 from agenda.scheduling.selection import ScheduleContext, WeightedSelector, default_rules
 from fk.models import Scheduleitem, Video
 
@@ -24,9 +25,15 @@ logger = logging.getLogger(__name__)
 MINIMUM_GAP = datetime.timedelta(seconds=300)
 
 
-def fill_agenda_with_jukebox(start=None, days=1, rng=None):
+def fill_agenda_with_jukebox(start=None, days=None, rng=None):
     start = start or timezone.now()
-    end = start + datetime.timedelta(days=days)
+    if days is None:
+        # The production default: draft through the end of the open
+        # broadcast week, so every week is complete before it opens for
+        # member picks (see agenda.scheduling.policy).
+        end = scheduling_horizon(now=start)
+    else:
+        end = start + datetime.timedelta(days=days)
 
     # A filler must have a length that actually advances the schedule
     # clock; the planner would otherwise place a zero-length video once

--- a/agenda/scheduling/jukebox.py
+++ b/agenda/scheduling/jukebox.py
@@ -36,18 +36,17 @@ def fill_agenda_with_jukebox(start=None, days=1):
     # feeds the jukebox CSV, whose output is a frozen contract.
     candidates = Video.objects.fillers().exclude(duration__lte=datetime.timedelta(0)).order_by("?")
 
-    jukebox_choices = items_for_gap(start, end, candidates)
-    for schedobj in jukebox_choices:
-        video = schedobj["video"]
+    placements = items_for_gap(start, end, candidates)
+    for placement in placements:
         item = Scheduleitem(
-            video=video,
+            video=placement.video,
             schedulereason=Scheduleitem.REASON_JUKEBOX,
-            starttime=schedobj["starttime"],
-            duration=video.duration,
+            starttime=placement.starttime,
+            duration=placement.video.duration,
         )
         item.save()
 
-    return jukebox_choices
+    return placements
 
 
 def next_whole_minute(dt):
@@ -63,6 +62,14 @@ def next_whole_minute(dt):
 def floor_minute(dt):
     """Returns the datetime with seconds and microseconds cleared"""
     return dt.replace(second=0, microsecond=0)
+
+
+@dataclass(frozen=True)
+class Placement:
+    """One planned (not yet saved) filler: this video at this time."""
+
+    video: Video
+    starttime: datetime.datetime
 
 
 @dataclass(frozen=True)
@@ -124,8 +131,8 @@ def free_gaps(
 def items_for_gap(start, end, candidates):
     """Plan (but do not save) filler placements between `start` and `end`.
 
-    Returns a list of `{"id", "starttime", "video"}` dicts, skipping any
-    stretch already occupied by an existing Scheduleitem.
+    Returns a list of `Placement`s, skipping any stretch already occupied
+    by an existing Scheduleitem.
     """
     logger.info("Being asked to fill gap from %s to %s", start, end)
 
@@ -190,7 +197,7 @@ def _fill_time_with_jukebox(start, end, videos, current_pool=None):
             if not video:
                 return new_items, rejected_videos + video_pool
         rejected_videos.extend(new_rejects)
-        new_items.append({"id": video.id, "starttime": current_time, "video": video})
+        new_items.append(Placement(video=video, starttime=current_time))
         logger.info("Added video %s at curr time %s", video.id, current_time.strftime("%H:%M:%S"))
         current_time = next_whole_minute(current_time + video.duration)
 

--- a/agenda/scheduling/jukebox.py
+++ b/agenda/scheduling/jukebox.py
@@ -152,14 +152,12 @@ def items_for_gap(start, end, candidates, selector=None):
     """
     logger.info("Being asked to fill gap from %s to %s", start, end)
 
-    # Include the surrounding items, so that programming which starts
-    # before the window but overruns into it still counts as occupied.
-    startdt, enddt = Scheduleitem.objects.expand_to_surrounding(start, end)
+    # overlapping() is the one definition of occupied airtime, and it
+    # includes programming that starts before the window but overruns
+    # into it.
     occupied = [
         (item.starttime, item.endtime())
-        for item in Scheduleitem.objects.filter(
-            starttime__gte=startdt, starttime__lte=enddt
-        ).order_by("starttime")
+        for item in Scheduleitem.objects.overlapping(start, end).order_by("starttime")
     ]
 
     if selector is None:

--- a/agenda/scheduling/jukebox.py
+++ b/agenda/scheduling/jukebox.py
@@ -9,12 +9,18 @@ programming that is already scheduled.
 
 import datetime
 import logging
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
 
 from django.utils import timezone
 
 from fk.models import Scheduleitem, Video
 
 logger = logging.getLogger(__name__)
+
+# The smallest gap the jukebox will try to fill. The boundary is
+# exclusive: a gap of exactly this length is left empty.
+MINIMUM_GAP = datetime.timedelta(seconds=300)
 
 
 def fill_agenda_with_jukebox(start=None, days=1):
@@ -44,13 +50,75 @@ def fill_agenda_with_jukebox(start=None, days=1):
     return jukebox_choices
 
 
-def ceil_minute(dt):
+def next_whole_minute(dt):
+    """The whole minute strictly after `dt` -- even if `dt` is one already.
+
+    Deliberately not a true ceiling: filling starts on the minute *after*
+    the window opens, and the tests pin that a 12:00:00 start places its
+    first item at 12:01.
+    """
     return floor_minute(dt) + datetime.timedelta(minutes=1)
 
 
 def floor_minute(dt):
     """Returns the datetime with seconds and microseconds cleared"""
     return dt.replace(second=0, microsecond=0)
+
+
+@dataclass(frozen=True)
+class Gap:
+    """A free, minute-aligned stretch of airtime."""
+
+    start: datetime.datetime
+    end: datetime.datetime
+
+    @property
+    def duration(self) -> datetime.timedelta:
+        return self.end - self.start
+
+
+def free_gaps(
+    start: datetime.datetime,
+    end: datetime.datetime,
+    occupied: Iterable[tuple[datetime.datetime, datetime.datetime]],
+) -> Iterator[Gap]:
+    """Yield the usable free intervals inside [start, end].
+
+    `occupied` is (starttime, endtime) pairs of airtime already spoken
+    for, sorted by starttime. Every boundary is a whole-minute rule:
+    filling starts on the whole minute after `start`, a gap ends on the
+    last whole minute before an occupied stretch and resumes on the whole
+    minute after it, and a gap of exactly MINIMUM_GAP is too short to use.
+    """
+    start_of_gap = next_whole_minute(start)
+    end = floor_minute(end)
+    pending = list(occupied)
+
+    while True:
+        end_of_gap = end
+        resume_at = None
+        while pending:
+            occupied_start, occupied_end = pending.pop(0)
+            # Already behind us; an item ending exactly at start_of_gap
+            # still bounds the (then empty) gap, so the comparison is strict.
+            if occupied_end < start_of_gap:
+                continue
+            if occupied_start > end:
+                # Beyond the window, as is everything after it.
+                break
+            end_of_gap = floor_minute(occupied_start)
+            resume_at = next_whole_minute(occupied_end)
+            break
+
+        gap = Gap(start_of_gap, end_of_gap)
+        if gap.duration > MINIMUM_GAP:
+            yield gap
+        else:
+            logger.info("Not filling %d second gap", gap.duration.total_seconds())
+
+        if resume_at is None or end_of_gap >= end:
+            return
+        start_of_gap = resume_at
 
 
 def items_for_gap(start, end, candidates):
@@ -60,58 +128,22 @@ def items_for_gap(start, end, candidates):
     stretch already occupied by an existing Scheduleitem.
     """
     logger.info("Being asked to fill gap from %s to %s", start, end)
-    # The smallest gap this function will try to fill
-    MINIMUM_GAP_SECONDS = 300
 
-    # Get a list of previously scheduled videos
+    # Include the surrounding items, so that programming which starts
+    # before the window but overruns into it still counts as occupied.
     startdt, enddt = Scheduleitem.objects.expand_to_surrounding(start, end)
-    already_scheduled = list(
-        Scheduleitem.objects.filter(starttime__gte=startdt, starttime__lte=enddt).order_by(
-            "starttime"
-        )
-    )
-
-    start_of_gap = ceil_minute(start)
-    end = floor_minute(end)
+    occupied = [
+        (item.starttime, item.endtime())
+        for item in Scheduleitem.objects.filter(
+            starttime__gte=startdt, starttime__lte=enddt
+        ).order_by("starttime")
+    ]
 
     pool = None
     full_items = []
-    while True:
-        end_of_gap = end
-
-        # Get the first video already existing in schedule
-        # that falls within the current time range
-        if len(already_scheduled):
-            extant_video = already_scheduled.pop(0)
-
-            # Keep trying until we find one that ends
-            # inside the range we are working with
-            if extant_video.endtime() < start_of_gap:
-                continue
-
-            # If it doesn't begin until after the
-            # end of our window, the window is
-            # empty; otherwise this video is now
-            # the end of our gap
-            if extant_video.starttime > end:
-                extant_video = None
-            else:
-                end_of_gap = floor_minute(extant_video.starttime)
-
-        gap = (end_of_gap - start_of_gap).total_seconds()
-
-        if gap > MINIMUM_GAP_SECONDS:
-            (items, pool) = _fill_time_with_jukebox(
-                start_of_gap, end_of_gap, candidates, current_pool=pool
-            )
-            full_items.extend(items)
-        else:
-            logger.info("Not filling %d second gap", gap)
-
-        if end_of_gap >= end:
-            break
-
-        start_of_gap = ceil_minute(extant_video.endtime())
+    for gap in free_gaps(start, end, occupied):
+        (items, pool) = _fill_time_with_jukebox(gap.start, gap.end, candidates, current_pool=pool)
+        full_items.extend(items)
     return full_items
 
 
@@ -160,6 +192,6 @@ def _fill_time_with_jukebox(start, end, videos, current_pool=None):
         rejected_videos.extend(new_rejects)
         new_items.append({"id": video.id, "starttime": current_time, "video": video})
         logger.info("Added video %s at curr time %s", video.id, current_time.strftime("%H:%M:%S"))
-        current_time = ceil_minute(current_time + video.duration)
+        current_time = next_whole_minute(current_time + video.duration)
 
     return new_items, rejected_videos + video_pool

--- a/agenda/scheduling/jukebox.py
+++ b/agenda/scheduling/jukebox.py
@@ -9,7 +9,8 @@ programming that is already scheduled.
 
 import datetime
 import logging
-from collections.abc import Iterable, Iterator
+import random
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 
 from django.utils import timezone
@@ -23,18 +24,19 @@ logger = logging.getLogger(__name__)
 MINIMUM_GAP = datetime.timedelta(seconds=300)
 
 
-def fill_agenda_with_jukebox(start=None, days=1):
+def fill_agenda_with_jukebox(start=None, days=1, rng=None):
     start = start or timezone.now()
     end = start + datetime.timedelta(days=days)
 
     # A filler must have a length that actually advances the schedule
-    # clock; `_fill_time_with_jukebox` would otherwise place a zero-length
-    # video once a minute for the whole window.  Video.duration defaults
-    # to zero, so this is ordinary unimported data, not corruption --
-    # negative lengths are barred by a check constraint on the model.
-    # Kept out of Video.objects.fillers() on purpose: that queryset also
-    # feeds the jukebox CSV, whose output is a frozen contract.
-    candidates = Video.objects.fillers().exclude(duration__lte=datetime.timedelta(0)).order_by("?")
+    # clock; the planner would otherwise place a zero-length video once
+    # a minute for the whole window.  Video.duration defaults to zero,
+    # so this is ordinary unimported data, not corruption -- negative
+    # lengths are barred by a check constraint on the model.  Kept out
+    # of Video.objects.fillers() on purpose: that queryset also feeds
+    # the jukebox CSV, whose output is a frozen contract.
+    candidates = list(Video.objects.fillers().exclude(duration__lte=datetime.timedelta(0)))
+    (rng or random).shuffle(candidates)
 
     placements = items_for_gap(start, end, candidates)
     for placement in placements:
@@ -146,59 +148,68 @@ def items_for_gap(start, end, candidates):
         ).order_by("starttime")
     ]
 
-    pool = None
-    full_items = []
+    selector = RoundRobinSelector(candidates)
+    placements = []
     for gap in free_gaps(start, end, occupied):
-        (items, pool) = _fill_time_with_jukebox(gap.start, gap.end, candidates, current_pool=pool)
-        full_items.extend(items)
-    return full_items
+        placements.extend(_fill_gap(gap, selector))
+    return placements
 
 
-def _fill_time_with_jukebox(start, end, videos, current_pool=None):
-    current_time = start
-    video_pool = current_pool or list(videos)
-    logger.info("Filling jukebox from %s to %s - %d in pool", start, end, len(video_pool))
-    rejected_videos = []
-    new_items = []
-
-    def plist(video_list):
-        return "[" + " ".join(str(v.id) for v in video_list) + "]"
-
-    def next_vid(first=False):
-        logger.debug("next vid %s rej %s pool %s", first, plist(rejected_videos), plist(video_pool))
-        if len(video_pool) < len(videos) and first:
-            video_pool.extend(list(videos))
-        if len(rejected_videos):
-            return rejected_videos.pop(0)
-        if not len(video_pool):
-            return None
-        return video_pool.pop(0)
-
-    while current_time < end:
-        video = next_vid(True)
-        if not video:
-            # Nothing eligible to draw from; leave the rest of the gap empty
-            # rather than dereferencing None below.
+def _fill_gap(gap: Gap, selector: "RoundRobinSelector") -> list[Placement]:
+    """Pack fillers into one gap, advancing minute-aligned after each."""
+    logger.info("Filling jukebox from %s to %s", gap.start, gap.end)
+    placements = []
+    current_time = gap.start
+    while current_time < gap.end:
+        video = selector.pick(gap.end - current_time)
+        if video is None:
+            # Nothing eligible fits; leave the rest of the gap empty.
             logger.info("No videos available to fill from %s", current_time)
             break
-        new_rejects = []
-
-        while current_time + video.duration > end:
-            logger.debug("end overshoots time %s", current_time + video.duration)
-            if video not in rejected_videos and video not in new_rejects:
-                new_rejects.append(video)
-            video = next_vid()
-            logger.debug(
-                "next vid is %s rejected %s new_rej %s",
-                video,
-                plist(rejected_videos),
-                plist(new_rejects),
-            )
-            if not video:
-                return new_items, rejected_videos + video_pool
-        rejected_videos.extend(new_rejects)
-        new_items.append(Placement(video=video, starttime=current_time))
+        placements.append(Placement(video=video, starttime=current_time))
         logger.info("Added video %s at curr time %s", video.id, current_time.strftime("%H:%M:%S"))
         current_time = next_whole_minute(current_time + video.duration)
+    return placements
 
-    return new_items, rejected_videos + video_pool
+
+class RoundRobinSelector:
+    """Draws videos in the order given, cycling through the whole list.
+
+    No video is drawn again until the rest of the list has had its turn.
+    A video too long for the remaining time keeps its place in line and
+    is retried first at the next pick; the caller supplies the order
+    (shuffled in production, fixed in tests).
+    """
+
+    def __init__(self, candidates: Sequence[Video]):
+        self._candidates = list(candidates)
+        self._pool = list(self._candidates)
+        self._deferred = []
+
+    def pick(self, remaining: datetime.timedelta) -> Video | None:
+        """The next video no longer than `remaining`, or None if none fit."""
+        # Top up before the first draw, so that the pool running dry
+        # mid-pick (everything left too long) ends this pick instead of
+        # retrying the same videos forever.
+        if len(self._pool) < len(self._candidates):
+            self._pool.extend(self._candidates)
+        skipped = []
+        while True:
+            video = self._draw()
+            if video is None:
+                # The too-long videos stay skipped rather than rejoining
+                # the deferred queue: they must not jump the line at a
+                # pick they already failed.
+                return None
+            if video.duration <= remaining:
+                self._deferred.extend(skipped)
+                return video
+            if video not in self._deferred and video not in skipped:
+                skipped.append(video)
+
+    def _draw(self) -> Video | None:
+        if self._deferred:
+            return self._deferred.pop(0)
+        if self._pool:
+            return self._pool.pop(0)
+        return None

--- a/agenda/scheduling/jukebox.py
+++ b/agenda/scheduling/jukebox.py
@@ -9,12 +9,12 @@ programming that is already scheduled.
 
 import datetime
 import logging
-import random
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 
 from django.utils import timezone
 
+from agenda.scheduling.selection import ScheduleContext, WeightedSelector, default_rules
 from fk.models import Scheduleitem, Video
 
 logger = logging.getLogger(__name__)
@@ -36,9 +36,14 @@ def fill_agenda_with_jukebox(start=None, days=1, rng=None):
     # of Video.objects.fillers() on purpose: that queryset also feeds
     # the jukebox CSV, whose output is a frozen contract.
     candidates = list(Video.objects.fillers().exclude(duration__lte=datetime.timedelta(0)))
-    (rng or random).shuffle(candidates)
 
-    placements = items_for_gap(start, end, candidates)
+    # The context seeds from everything already on the air in the
+    # window -- weekly-slot programming included -- so an organization
+    # the slots favor starts the day with its filler weight down.
+    context = ScheduleContext.from_schedule(start, end)
+    selector = WeightedSelector(candidates, context, default_rules(now=start), rng=rng)
+
+    placements = items_for_gap(start, end, candidates, selector=selector)
     for placement in placements:
         item = Scheduleitem(
             video=placement.video,
@@ -130,11 +135,13 @@ def free_gaps(
         start_of_gap = resume_at
 
 
-def items_for_gap(start, end, candidates):
+def items_for_gap(start, end, candidates, selector=None):
     """Plan (but do not save) filler placements between `start` and `end`.
 
     Returns a list of `Placement`s, skipping any stretch already occupied
-    by an existing Scheduleitem.
+    by an existing Scheduleitem. Videos are chosen by `selector`;
+    without one, a RoundRobinSelector cycles `candidates` in the order
+    given.
     """
     logger.info("Being asked to fill gap from %s to %s", start, end)
 
@@ -148,14 +155,15 @@ def items_for_gap(start, end, candidates):
         ).order_by("starttime")
     ]
 
-    selector = RoundRobinSelector(candidates)
+    if selector is None:
+        selector = RoundRobinSelector(candidates)
     placements = []
     for gap in free_gaps(start, end, occupied):
         placements.extend(_fill_gap(gap, selector))
     return placements
 
 
-def _fill_gap(gap: Gap, selector: "RoundRobinSelector") -> list[Placement]:
+def _fill_gap(gap: Gap, selector) -> list[Placement]:
     """Pack fillers into one gap, advancing minute-aligned after each."""
     logger.info("Filling jukebox from %s to %s", gap.start, gap.end)
     placements = []

--- a/agenda/scheduling/policy.py
+++ b/agenda/scheduling/policy.py
@@ -17,16 +17,24 @@ week after next is open, and later weeks are not yet drafted.
 """
 
 from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
 
 from django.utils import timezone
 
 FROZEN_WEEKS = 2  # the current week and the next
 DRAFTED_WEEKS = 3  # ...plus the open week the nightly jobs keep filled
 
+# The policy is defined in this zone, not the request's or the
+# process's: fkweb.middleware overrides Django's active timezone to UTC
+# for every /api/ request, so anchoring on timezone.localtime here
+# would put the API's idea of Monday midnight an hour or two off the
+# cron jobs'.
+TZ = ZoneInfo("Europe/Oslo")
+
 
 def week_start(moment: datetime) -> datetime:
-    """Monday 00:00, local time, of the broadcast week containing `moment`."""
-    local = timezone.localtime(moment)
+    """Monday 00:00, Europe/Oslo, of the broadcast week containing `moment`."""
+    local = moment.astimezone(TZ)
     monday = local.date() - timedelta(days=local.weekday())
     return _local_midnight(monday)
 
@@ -48,12 +56,12 @@ def is_frozen(starttime: datetime, now: datetime | None = None) -> bool:
 def freeze_message(boundary: datetime | None = None) -> str:
     """The refusal members see, stating when the open week starts."""
     boundary = boundary or freeze_boundary()
-    open_from = timezone.localtime(boundary).date().isoformat()
+    open_from = boundary.astimezone(TZ).date().isoformat()
     return f"The schedule is frozen before {open_from}; only the week starting then is open."
 
 
 def _weeks_after_week_start(now: datetime | None, weeks: int) -> datetime:
-    local = timezone.localtime(now or timezone.now())
+    local = (now or timezone.now()).astimezone(TZ)
     monday = local.date() - timedelta(days=local.weekday())
     return _local_midnight(monday + timedelta(weeks=weeks))
 
@@ -61,4 +69,4 @@ def _weeks_after_week_start(now: datetime | None, weeks: int) -> datetime:
 def _local_midnight(day: date) -> datetime:
     # Built from the wall-clock date and only then localized, so a week
     # containing a DST transition still ends on a true local midnight.
-    return timezone.make_aware(datetime.combine(day, time.min))
+    return datetime.combine(day, time.min, tzinfo=TZ)

--- a/agenda/scheduling/policy.py
+++ b/agenda/scheduling/policy.py
@@ -14,12 +14,19 @@ the whole policy and fits in three sentences for members:
 
 So at any moment the current and next broadcast weeks are frozen, the
 week after next is open, and later weeks are not yet drafted.
+
+Besides the clock boundaries, this module also owns the displacement
+rule -- what may be scheduled over: automatic jukebox filler gives way,
+deliberate programming never does. The weekly-slot filler and the
+schedule API both apply it from here.
 """
 
 from datetime import date, datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
 from django.utils import timezone
+
+from fk.models import Scheduleitem
 
 FROZEN_WEEKS = 2  # the current week and the next
 DRAFTED_WEEKS = 3  # ...plus the open week the nightly jobs keep filled
@@ -70,3 +77,43 @@ def _local_midnight(day: date) -> datetime:
     # Built from the wall-clock date and only then localized, so a week
     # containing a DST transition still ends on a true local midnight.
     return datetime.combine(day, time.min, tzinfo=TZ)
+
+
+def is_displaceable(item) -> bool:
+    """Whether a placement may be scheduled over `item`.
+
+    Only automatic jukebox filler gives way; deliberate programming --
+    slot placements, member picks, admin entries -- never does.
+    """
+    return item.schedulereason == Scheduleitem.REASON_JUKEBOX
+
+
+def airtime_conflicts(
+    start: datetime,
+    end: datetime,
+    exclude_pk: int | None = None,
+    for_update: bool = False,
+) -> tuple[list, list]:
+    """What stands in the way of placing something on [start, end).
+
+    Returns (blocking, displaceable), each ordered by starttime: items
+    that refuse the placement, and jukebox fillers that give way to it.
+    `for_update` locks the conflict rows for the enclosing transaction,
+    so concurrent displacements of the same fillers serialize.
+    """
+    conflicts = Scheduleitem.objects.overlapping(start, end).order_by("starttime")
+    if exclude_pk is not None:
+        conflicts = conflicts.exclude(pk=exclude_pk)
+    if for_update:
+        conflicts = conflicts.select_for_update()
+    items = list(conflicts)
+    blocking = [item for item in items if not is_displaceable(item)]
+    displaceable = [item for item in items if is_displaceable(item)]
+    return blocking, displaceable
+
+
+def displace(fillers: list) -> None:
+    """Delete jukebox fillers that a placement is scheduling over. The
+    nightly jukebox repacks whatever slivers this leaves behind."""
+    if fillers:
+        Scheduleitem.objects.filter(pk__in=[item.pk for item in fillers]).delete()

--- a/agenda/scheduling/policy.py
+++ b/agenda/scheduling/policy.py
@@ -1,0 +1,64 @@
+"""When the broadcast schedule is drafted, opened, and frozen.
+
+The unit of scheduling is the broadcast week: Monday 00:00 to the next
+Monday 00:00, Europe/Oslo. Every week has the same lifecycle, which is
+the whole policy and fits in three sentences for members:
+
+* Two Mondays before it airs, the nightly jobs draft the week: weekly
+  slots place their videos and the jukebox fills the rest.
+* For the following week, member organizations may adjust it through
+  the API -- their picks displace jukebox fillers.
+* From the Monday before it airs, the week is frozen: members can no
+  longer change it. (Staff can, and the jukebox may still fill airtime
+  that is genuinely empty -- dead air is worse than a late change.)
+
+So at any moment the current and next broadcast weeks are frozen, the
+week after next is open, and later weeks are not yet drafted.
+"""
+
+from datetime import date, datetime, time, timedelta
+
+from django.utils import timezone
+
+FROZEN_WEEKS = 2  # the current week and the next
+DRAFTED_WEEKS = 3  # ...plus the open week the nightly jobs keep filled
+
+
+def week_start(moment: datetime) -> datetime:
+    """Monday 00:00, local time, of the broadcast week containing `moment`."""
+    local = timezone.localtime(moment)
+    monday = local.date() - timedelta(days=local.weekday())
+    return _local_midnight(monday)
+
+
+def freeze_boundary(now: datetime | None = None) -> datetime:
+    """Items starting before this moment are frozen to members."""
+    return _weeks_after_week_start(now, FROZEN_WEEKS)
+
+
+def scheduling_horizon(now: datetime | None = None) -> datetime:
+    """How far ahead the nightly drafting jobs fill: end of the open week."""
+    return _weeks_after_week_start(now, DRAFTED_WEEKS)
+
+
+def is_frozen(starttime: datetime, now: datetime | None = None) -> bool:
+    return starttime < freeze_boundary(now)
+
+
+def freeze_message(boundary: datetime | None = None) -> str:
+    """The refusal members see, stating when the open week starts."""
+    boundary = boundary or freeze_boundary()
+    open_from = timezone.localtime(boundary).date().isoformat()
+    return f"The schedule is frozen before {open_from}; only the week starting then is open."
+
+
+def _weeks_after_week_start(now: datetime | None, weeks: int) -> datetime:
+    local = timezone.localtime(now or timezone.now())
+    monday = local.date() - timedelta(days=local.weekday())
+    return _local_midnight(monday + timedelta(weeks=weeks))
+
+
+def _local_midnight(day: date) -> datetime:
+    # Built from the wall-clock date and only then localized, so a week
+    # containing a DST transition still ends on a true local midnight.
+    return timezone.make_aware(datetime.combine(day, time.min))

--- a/agenda/scheduling/selection.py
+++ b/agenda/scheduling/selection.py
@@ -1,0 +1,171 @@
+"""Choosing which filler to play: scoring rules and the weighted draw.
+
+The jukebox planner (see :mod:`agenda.scheduling.jukebox`) asks a
+selector one question, repeatedly: given the time remaining in this
+gap, which video next?  This module answers with weighted randomness:
+every rule multiplies a candidate's weight, and the draw is
+proportional to the product -- preference, not decree, so material a
+rule frowns on still eventually airs.
+
+A rule is anything with ``weight(video, context) -> float`` returning a
+non-negative multiplier, where 1.0 is indifference and 0.0 a veto.
+"""
+
+import datetime
+import logging
+import random
+from collections import Counter, defaultdict
+from collections.abc import Sequence
+
+from fk.models import Scheduleitem, Video
+
+logger = logging.getLogger(__name__)
+
+
+class ScheduleContext:
+    """What is already on the air in the window, kept current as picks land.
+
+    Built from every Scheduleitem overlapping the window -- weekly-slot
+    programming included, which is what lets OrganizationDiversity
+    downplay an organization the slots already favor.
+    """
+
+    def __init__(self):
+        self.org_airtime = defaultdict(datetime.timedelta)
+        self.total_airtime = datetime.timedelta(0)
+        self.times_played = Counter()
+        self.last_video_id = None
+
+    @classmethod
+    def from_schedule(cls, start: datetime.datetime, end: datetime.datetime):
+        context = cls()
+        for item in Scheduleitem.objects.overlapping(start, end).select_related("video"):
+            context._count(item.video, item.duration)
+        return context
+
+    def record(self, video: Video) -> None:
+        """Note a pick the selector just made, so later weights see it."""
+        self._count(video, video.duration)
+        self.last_video_id = video.id
+
+    def _count(self, video: Video | None, duration: datetime.timedelta) -> None:
+        # An edge item's airtime counts in full even where it leaves the
+        # window; shares are a steering signal, not bookkeeping.
+        self.total_airtime += duration
+        if video is None:
+            return
+        self.times_played[video.id] += 1
+        if video.organization_id is not None:
+            self.org_airtime[video.organization_id] += duration
+
+    def organization_share(self, organization_id: int | None) -> float:
+        """The organization's fraction of all airtime counted so far."""
+        if organization_id is None or not self.total_airtime:
+            return 0.0
+        return self.org_airtime[organization_id] / self.total_airtime
+
+
+class Freshness:
+    """Newer uploads weigh more, to keep the airwaves fresh.
+
+    Half the weight per `half_life` of age, levelling off at `floor` so
+    ancient material still airs. A video with no upload time recorded is
+    treated as ancient.
+    """
+
+    def __init__(
+        self,
+        now: datetime.datetime,
+        half_life: datetime.timedelta = datetime.timedelta(days=365),
+        floor: float = 0.2,
+    ):
+        self.now = now
+        self.half_life = half_life
+        self.floor = floor
+
+    def weight(self, video: Video, context: ScheduleContext) -> float:
+        if video.uploaded_time is None:
+            return self.floor
+        age = self.now - video.uploaded_time
+        if age <= datetime.timedelta(0):
+            return 1.0
+        return self.floor + (1.0 - self.floor) * 0.5 ** (age / self.half_life)
+
+
+class OrganizationDiversity:
+    """No one organization should dominate a day's schedule.
+
+    Weight is (1 - share) ** strength, so the more of the window's
+    airtime an organization already holds -- weekly slots included --
+    the less its videos weigh. The floor keeps this a preference, never
+    a veto: when one organization owns the whole window (a share of
+    1.0), zeroing it would zero every candidate alike and knock out
+    RepeatAvoidance via the selector's uniform fallback.
+    """
+
+    def __init__(self, strength: float = 1.0, floor: float = 0.05):
+        self.strength = strength
+        self.floor = floor
+
+    def weight(self, video: Video, context: ScheduleContext) -> float:
+        share = context.organization_share(video.organization_id)
+        return max((1.0 - share) ** self.strength, self.floor)
+
+
+class RepeatAvoidance:
+    """Never the same video twice in a row; beyond that, each earlier
+    play in the window halves the weight."""
+
+    def __init__(self, penalty: float = 0.5):
+        self.penalty = penalty
+
+    def weight(self, video: Video, context: ScheduleContext) -> float:
+        if video.id == context.last_video_id:
+            return 0.0
+        return self.penalty ** context.times_played[video.id]
+
+
+def default_rules(now: datetime.datetime) -> list:
+    return [Freshness(now=now), OrganizationDiversity(), RepeatAvoidance()]
+
+
+class WeightedSelector:
+    """Draws the next filler at random, in proportion to the product of
+    every rule's weight.
+
+    If every fitting candidate weighs zero -- say the only video short
+    enough just played -- the draw falls back to uniform: dead air is
+    worse than repetition.
+    """
+
+    def __init__(
+        self,
+        candidates: Sequence[Video],
+        context: ScheduleContext,
+        rules: Sequence,
+        rng: random.Random | None = None,
+    ):
+        # A non-positive duration cannot advance the schedule clock, so
+        # it would be drawn once a minute for the whole window.
+        self._candidates = [v for v in candidates if v.duration > datetime.timedelta(0)]
+        self._context = context
+        self._rules = list(rules)
+        self._rng = rng or random
+
+    def pick(self, remaining: datetime.timedelta) -> Video | None:
+        """The next video no longer than `remaining`, or None if none fit."""
+        fitting = [v for v in self._candidates if v.duration <= remaining]
+        if not fitting:
+            return None
+        weights = [self._weight(video) for video in fitting]
+        if not any(weights):
+            weights = None  # uniform
+        video = self._rng.choices(fitting, weights=weights, k=1)[0]
+        self._context.record(video)
+        return video
+
+    def _weight(self, video: Video) -> float:
+        weight = 1.0
+        for rule in self._rules:
+            weight *= rule.weight(video, self._context)
+        return weight

--- a/agenda/scheduling/weekly_slots.py
+++ b/agenda/scheduling/weekly_slots.py
@@ -13,9 +13,15 @@ the jukebox got to first.
 import logging
 from datetime import timedelta
 
+from django.db import transaction
 from django.utils import timezone
 
-from agenda.scheduling.policy import freeze_boundary, scheduling_horizon
+from agenda.scheduling.policy import (
+    airtime_conflicts,
+    displace,
+    freeze_boundary,
+    scheduling_horizon,
+)
 from fk.models import Scheduleitem, WeeklySlot
 
 logger = logging.getLogger(__name__)
@@ -61,24 +67,23 @@ def _fill_occurrence(slot, starttime, frozen_until):
         logger.info("Couldn't get a video to use in slot!")
         return
     end = starttime + slot.duration
-    conflicts = list(Scheduleitem.objects.overlapping(starttime, end))
 
-    if any(item.schedulereason != Scheduleitem.REASON_JUKEBOX for item in conflicts):
-        # Something deliberate is on the air across this slot. Note this
-        # includes an item that started *before* the slot and runs into it.
-        logger.info("Already something scheduled across %s; skipping slot", starttime)
-        return
-    if conflicts:
-        if starttime < frozen_until:
+    with transaction.atomic():
+        blocking, displaceable = airtime_conflicts(starttime, end, for_update=True)
+        if blocking:
+            # Something deliberate is on the air across this slot. Note this
+            # includes an item that started *before* the slot and runs into it.
+            logger.info("Already something scheduled across %s; skipping slot", starttime)
+            return
+        if displaceable and starttime < frozen_until:
             # Frozen weeks change as little as possible: only genuinely
             # empty airtime may still be filled.
             logger.info("Not displacing jukebox fillers at %s inside the frozen weeks", starttime)
             return
-        Scheduleitem.objects.filter(pk__in=[item.pk for item in conflicts]).delete()
-
-    Scheduleitem.objects.create(
-        video=video,
-        schedulereason=Scheduleitem.REASON_AUTO,
-        starttime=starttime,
-        duration=video.duration,
-    )
+        displace(displaceable)
+        Scheduleitem.objects.create(
+            video=video,
+            schedulereason=Scheduleitem.REASON_AUTO,
+            starttime=starttime,
+            duration=video.duration,
+        )

--- a/agenda/scheduling/weekly_slots.py
+++ b/agenda/scheduling/weekly_slots.py
@@ -1,21 +1,32 @@
 # Copyright (c) 2012-2013 Benjamin Bruheim <grolgh@gmail.com>
 # This file is covered by the LGPLv3 or later, read COPYING for details.
-"""Placing one video per WeeklySlot.
+"""Placing one video per WeeklySlot occurrence.
 
-Runs before the jukebox (see :mod:`agenda.scheduling.jukebox`), which then
-fills whatever airtime these slots leave empty.
+Runs before the jukebox (see :mod:`agenda.scheduling.jukebox`) and, like
+it, drafts through the end of the open broadcast week (see
+:mod:`agenda.scheduling.policy`). Airtime taken by anything but jukebox
+fillers is respected; jukebox fillers are displaced outside the freeze
+boundary, so a newly defined slot does not wait two weeks for airtime
+the jukebox got to first.
 """
 
 import logging
+from datetime import timedelta
 
+from django.utils import timezone
+
+from agenda.scheduling.policy import freeze_boundary, scheduling_horizon
 from fk.models import Scheduleitem, WeeklySlot
 
 logger = logging.getLogger(__name__)
 
 
-def fill_next_weeks_agenda():
-    slots = WeeklySlot.objects.all()
+def fill_next_weeks_agenda(now=None):
+    now = now or timezone.now()
+    horizon = scheduling_horizon(now)
+    frozen_until = freeze_boundary(now)
 
+    slots = WeeklySlot.objects.all()
     if len(slots) == 0:
         logger.warning("No WeeklySlots defined; exiting")
         return
@@ -24,23 +35,50 @@ def fill_next_weeks_agenda():
         if not slot.purpose:
             logger.info("No purpose connected, so nothing to fill")
             continue
-        video = slot.purpose.single_video(slot.duration)
-        if not video:
-            logger.info("Couldn't get a video to use in slot!")
-            continue
-        next_datetime = slot.next_datetime()
-        end_next_datetime = next_datetime + slot.duration
+        for starttime in _occurrences(slot, now, horizon):
+            _fill_occurrence(slot, starttime, frozen_until)
 
-        if Scheduleitem.objects.overlapping(next_datetime, end_next_datetime).exists():
-            # Something is already on the air across this slot. Note this
-            # includes an item that started *before* the slot and runs into
-            # it, which the old starttime-only check could not see.
-            logger.info("Already something scheduled across %s; skipping slot", next_datetime)
-            continue
-        item = Scheduleitem(
-            video=video,
-            schedulereason=Scheduleitem.REASON_AUTO,
-            starttime=next_datetime,
-            duration=video.duration,
-        )
-        item.save()
+
+def _occurrences(slot, now, horizon):
+    """Every time `slot` comes up between `now` and `horizon`."""
+    day = slot.next_date(timezone.localtime(now).date())
+    if slot.next_datetime(from_date=day) <= now:
+        # Today is the slot's weekday, but its start time has passed.
+        day += timedelta(days=7)
+    while True:
+        occurrence = slot.next_datetime(from_date=day)
+        if occurrence >= horizon:
+            return
+        yield occurrence
+        day += timedelta(days=7)
+
+
+def _fill_occurrence(slot, starttime, frozen_until):
+    # Chosen per occurrence, so the least_scheduled strategy sees each
+    # placement it just made.
+    video = slot.purpose.single_video(slot.duration)
+    if not video:
+        logger.info("Couldn't get a video to use in slot!")
+        return
+    end = starttime + slot.duration
+    conflicts = list(Scheduleitem.objects.overlapping(starttime, end))
+
+    if any(item.schedulereason != Scheduleitem.REASON_JUKEBOX for item in conflicts):
+        # Something deliberate is on the air across this slot. Note this
+        # includes an item that started *before* the slot and runs into it.
+        logger.info("Already something scheduled across %s; skipping slot", starttime)
+        return
+    if conflicts:
+        if starttime < frozen_until:
+            # Frozen weeks change as little as possible: only genuinely
+            # empty airtime may still be filled.
+            logger.info("Not displacing jukebox fillers at %s inside the frozen weeks", starttime)
+            return
+        Scheduleitem.objects.filter(pk__in=[item.pk for item in conflicts]).delete()
+
+    Scheduleitem.objects.create(
+        video=video,
+        schedulereason=Scheduleitem.REASON_AUTO,
+        starttime=starttime,
+        duration=video.duration,
+    )

--- a/agenda/tests/test_fill_next_weeks_agenda.py
+++ b/agenda/tests/test_fill_next_weeks_agenda.py
@@ -199,9 +199,7 @@ def test_fills_a_slot_that_an_earlier_item_stops_short_of(
     assert OPEN_OCCURRENCE in [item.starttime for item in slot_items()]
 
 
-def test_displaces_jukebox_fillers_in_the_open_week(
-    video: Video, purpose: SchedulePurpose
-) -> None:
+def test_displaces_jukebox_fillers_in_the_open_week(video: Video, purpose: SchedulePurpose) -> None:
     """A newly defined slot must not wait for airtime the jukebox got to
     first: outside the freeze boundary its fillers are deleted."""
     make_slot(purpose)

--- a/agenda/tests/test_fill_next_weeks_agenda.py
+++ b/agenda/tests/test_fill_next_weeks_agenda.py
@@ -1,14 +1,22 @@
 """
-fill_next_weeks_agenda places one video per WeeklySlot; it runs from
-cron via the management command and had zero coverage.
+fill_next_weeks_agenda places one video per WeeklySlot occurrence, for
+every occurrence between now and the scheduling horizon (the end of the
+open broadcast week); it runs nightly from cron before the jukebox.
+
+The fixed clock is a Thursday, so a Monday slot has exactly two
+occurrences before the horizon: one in the frozen next week (Mon 7-1)
+and one in the open week (Mon 7-8, the freeze boundary's own Monday).
+The tests lean on that pair to pin the displacement rules.
 """
 
-from datetime import time, timedelta
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 from django.core.management import call_command
 from django.utils import timezone
 
+from agenda.scheduling import weekly_slots
 from agenda.scheduling.weekly_slots import fill_next_weeks_agenda
 from fk.models import (
     Organization,
@@ -20,6 +28,13 @@ from fk.models import (
 )
 
 pytestmark = pytest.mark.django_db
+
+OSLO = ZoneInfo("Europe/Oslo")
+# A Thursday; broadcast week Mon 2019-06-24. Freeze boundary Mon 07-08,
+# horizon Mon 07-15.
+NOW = datetime(2019, 6, 27, 12, tzinfo=OSLO)
+FROZEN_OCCURRENCE = datetime(2019, 7, 1, 12, tzinfo=OSLO)
+OPEN_OCCURRENCE = datetime(2019, 7, 8, 12, tzinfo=OSLO)
 
 
 @pytest.fixture
@@ -58,21 +73,49 @@ def make_slot(purpose: SchedulePurpose | None, **fields) -> WeeklySlot:
     )
 
 
-def test_fills_a_slot_with_the_purposes_video(video: Video, purpose: SchedulePurpose) -> None:
-    slot = make_slot(purpose)
+def occupy(video: Video, starttime: datetime, duration: timedelta, reason: int) -> Scheduleitem:
+    return Scheduleitem.objects.create(
+        video=video, schedulereason=reason, starttime=starttime, duration=duration
+    )
 
-    fill_next_weeks_agenda()
 
-    item = Scheduleitem.objects.get()
-    assert item.video == video
-    assert item.schedulereason == Scheduleitem.REASON_AUTO
-    assert item.starttime == slot.next_datetime()
+def slot_items() -> list[Scheduleitem]:
+    return list(
+        Scheduleitem.objects.filter(schedulereason=Scheduleitem.REASON_AUTO).order_by("starttime")
+    )
+
+
+def test_fills_every_occurrence_up_to_the_horizon(video: Video, purpose: SchedulePurpose) -> None:
+    make_slot(purpose)
+
+    fill_next_weeks_agenda(now=NOW)
+
+    items = slot_items()
+    assert [item.starttime for item in items] == [FROZEN_OCCURRENCE, OPEN_OCCURRENCE]
+    assert {item.video for item in items} == {video}
     # The item takes the video's duration, not the slot's.
-    assert item.duration == video.duration
+    assert {item.duration for item in items} == {video.duration}
+
+
+def test_todays_occurrence_counts_only_while_still_ahead(
+    video: Video, purpose: SchedulePurpose
+) -> None:
+    """NOW is Thursday noon; a Thursday slot at 11:00 has passed and
+    starts next week, one at 13:00 is still ahead and starts today."""
+    passed = make_slot(purpose, day=3, start_time=time(11, 0))
+    ahead = make_slot(purpose, day=3, start_time=time(13, 0))
+
+    fill_next_weeks_agenda(now=NOW)
+
+    starts = [item.starttime for item in slot_items()]
+    assert datetime(2019, 6, 27, 13, tzinfo=OSLO) in starts
+    assert datetime(2019, 6, 27, 11, tzinfo=OSLO) not in starts
+    assert datetime(2019, 7, 4, 11, tzinfo=OSLO) in starts
+    assert passed and ahead  # fixtures used
 
 
 def test_does_nothing_without_slots(video: Video) -> None:
-    fill_next_weeks_agenda()
+    fill_next_weeks_agenda(now=NOW)
 
     assert not Scheduleitem.objects.exists()
 
@@ -80,7 +123,7 @@ def test_does_nothing_without_slots(video: Video) -> None:
 def test_skips_slots_without_a_purpose(video: Video) -> None:
     make_slot(None)
 
-    fill_next_weeks_agenda()
+    fill_next_weeks_agenda(now=NOW)
 
     assert not Scheduleitem.objects.exists()
 
@@ -97,73 +140,121 @@ def test_skips_slots_whose_purpose_has_no_eligible_video(
     )
     make_slot(purpose, duration=timedelta(hours=1))
 
-    fill_next_weeks_agenda()
+    fill_next_weeks_agenda(now=NOW)
 
     assert not Scheduleitem.objects.exists()
 
 
-def test_leaves_an_already_occupied_slot_alone(video: Video, purpose: SchedulePurpose) -> None:
-    slot = make_slot(purpose)
-    existing = Scheduleitem.objects.create(
-        video=video,
-        schedulereason=Scheduleitem.REASON_ADMIN,
-        starttime=slot.next_datetime() + timedelta(minutes=30),
-        duration=timedelta(minutes=10),
-    )
-
-    fill_next_weeks_agenda()
-
-    assert list(Scheduleitem.objects.all()) == [existing]
+# --- what already-occupied airtime does ------------------------------------
 
 
-def test_leaves_a_slot_alone_when_an_earlier_item_overruns_into_it(
+def test_an_occupied_occurrence_is_skipped_but_the_others_still_fill(
     video: Video, purpose: SchedulePurpose
 ) -> None:
-    """The case the old starttime-only check could not see.
-
-    An item that begins before the slot and runs past its start occupies the
-    airtime just as surely as one that begins inside it. Observed live: two
-    REASON_AUTO items overlapping by up to 40 seconds.
-    """
-    slot = make_slot(purpose)
-    existing = Scheduleitem.objects.create(
-        video=video,
-        schedulereason=Scheduleitem.REASON_JUKEBOX,
-        starttime=slot.next_datetime() - timedelta(minutes=5),
-        duration=timedelta(minutes=10),
+    make_slot(purpose)
+    occupy(
+        video,
+        FROZEN_OCCURRENCE + timedelta(minutes=30),
+        timedelta(minutes=10),
+        Scheduleitem.REASON_ADMIN,
     )
 
-    fill_next_weeks_agenda()
+    fill_next_weeks_agenda(now=NOW)
 
-    assert list(Scheduleitem.objects.all()) == [existing]
+    assert [item.starttime for item in slot_items()] == [OPEN_OCCURRENCE]
+
+
+def test_an_earlier_item_overrunning_into_the_slot_occupies_it(
+    video: Video, purpose: SchedulePurpose
+) -> None:
+    """An item that begins before the slot and runs past its start
+    occupies the airtime just as surely as one that begins inside it."""
+    make_slot(purpose)
+    occupy(
+        video,
+        OPEN_OCCURRENCE - timedelta(minutes=5),
+        timedelta(minutes=10),
+        Scheduleitem.REASON_USER,
+    )
+
+    fill_next_weeks_agenda(now=NOW)
+
+    assert [item.starttime for item in slot_items()] == [FROZEN_OCCURRENCE]
 
 
 def test_fills_a_slot_that_an_earlier_item_stops_short_of(
     video: Video, purpose: SchedulePurpose
 ) -> None:
     """Back-to-back is not a conflict: the bounds are half-open."""
-    slot = make_slot(purpose)
-    Scheduleitem.objects.create(
-        video=video,
-        schedulereason=Scheduleitem.REASON_JUKEBOX,
-        starttime=slot.next_datetime() - timedelta(minutes=10),
-        duration=timedelta(minutes=10),
+    make_slot(purpose)
+    occupy(
+        video,
+        OPEN_OCCURRENCE - timedelta(minutes=10),
+        timedelta(minutes=10),
+        Scheduleitem.REASON_USER,
     )
 
-    fill_next_weeks_agenda()
+    fill_next_weeks_agenda(now=NOW)
 
-    assert Scheduleitem.objects.filter(schedulereason=Scheduleitem.REASON_AUTO).count() == 1
+    assert OPEN_OCCURRENCE in [item.starttime for item in slot_items()]
 
 
-def test_management_command_runs_the_filler(video: Video, purpose: SchedulePurpose) -> None:
+def test_displaces_jukebox_fillers_in_the_open_week(
+    video: Video, purpose: SchedulePurpose
+) -> None:
+    """A newly defined slot must not wait for airtime the jukebox got to
+    first: outside the freeze boundary its fillers are deleted."""
+    make_slot(purpose)
+    displaced = occupy(
+        video,
+        OPEN_OCCURRENCE + timedelta(minutes=10),
+        timedelta(minutes=10),
+        Scheduleitem.REASON_JUKEBOX,
+    )
+
+    fill_next_weeks_agenda(now=NOW)
+
+    assert OPEN_OCCURRENCE in [item.starttime for item in slot_items()]
+    assert not Scheduleitem.objects.filter(pk=displaced.pk).exists()
+
+
+def test_does_not_displace_jukebox_fillers_in_the_frozen_weeks(
+    video: Video, purpose: SchedulePurpose
+) -> None:
+    """Inside the freeze boundary only genuinely empty airtime may be
+    filled; the published week keeps the fillers it was published with."""
+    make_slot(purpose)
+    published = occupy(
+        video,
+        FROZEN_OCCURRENCE + timedelta(minutes=10),
+        timedelta(minutes=10),
+        Scheduleitem.REASON_JUKEBOX,
+    )
+
+    fill_next_weeks_agenda(now=NOW)
+
+    assert [item.starttime for item in slot_items()] == [OPEN_OCCURRENCE]
+    assert Scheduleitem.objects.filter(pk=published.pk).exists()
+
+
+# --- the entry points the cron actually calls -------------------------------
+
+
+def test_management_command_runs_the_filler(
+    monkeypatch: pytest.MonkeyPatch, video: Video, purpose: SchedulePurpose
+) -> None:
+    monkeypatch.setattr(weekly_slots.timezone, "now", lambda: NOW)
     make_slot(purpose)
 
     call_command("fill_next_weeks_agenda")
 
-    assert Scheduleitem.objects.count() == 1
+    assert len(slot_items()) == 2
 
 
-def test_jukebox_management_command_fills_two_days(organization: Organization) -> None:
+def test_jukebox_management_command_fills_to_the_horizon(
+    monkeypatch: pytest.MonkeyPatch, organization: Organization
+) -> None:
+    monkeypatch.setattr(timezone, "now", lambda: NOW)
     organization.fkmember = True
     organization.save()
     Video.objects.create(
@@ -177,11 +268,11 @@ def test_jukebox_management_command_fills_two_days(organization: Organization) -
 
     call_command("fill_agenda_with_jukebox")
 
-    count = Scheduleitem.objects.count()
-    # Two days of hour-long slots, minus rounding at the edges.
-    assert 44 <= count <= 48
-    assert set(Scheduleitem.objects.values_list("schedulereason", flat=True)) == {
-        Scheduleitem.REASON_JUKEBOX
-    }
-    latest = Scheduleitem.objects.order_by("starttime").last()
-    assert latest.starttime <= timezone.now() + timedelta(days=2)
+    items = Scheduleitem.objects.order_by("starttime")
+    assert set(items.values_list("schedulereason", flat=True)) == {Scheduleitem.REASON_JUKEBOX}
+    horizon = datetime(2019, 7, 15, tzinfo=OSLO)
+    assert items.first().starttime >= NOW
+    assert items.last().starttime < horizon
+    # The horizon week is complete: the last filler ends within the last
+    # hour-and-a-rounding-minute before it.
+    assert items.last().endtime() > horizon - timedelta(minutes=62)

--- a/agenda/tests/test_free_gaps.py
+++ b/agenda/tests/test_free_gaps.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for the jukebox's gap discovery, `free_gaps`.
+
+These run against plain datetimes -- no database. The integration tests
+in test_jukebox_fill.py pin the same whole-minute rules end to end; here
+each boundary is exercised directly.
+"""
+
+import datetime
+from zoneinfo import ZoneInfo
+
+from agenda.scheduling.jukebox import Gap, free_gaps
+
+OSLO = ZoneInfo("Europe/Oslo")
+NOON = datetime.datetime(2019, 6, 30, 12, tzinfo=OSLO)
+
+
+def at(minutes: float = 0, seconds: float = 0) -> datetime.datetime:
+    return NOON + datetime.timedelta(minutes=minutes, seconds=seconds)
+
+
+def gaps(start, end, occupied=()) -> list[Gap]:
+    return list(free_gaps(start, end, occupied))
+
+
+def test_an_empty_window_is_one_gap() -> None:
+    assert gaps(NOON, at(minutes=60)) == [Gap(at(minutes=1), at(minutes=60))]
+
+
+def test_the_window_start_rounds_forward_even_from_a_whole_minute() -> None:
+    """Filling starts on the minute *after* the window opens -- 12:00 sharp
+    included, which is what makes `next_whole_minute` not a true ceiling."""
+    assert gaps(at(seconds=0), at(minutes=30))[0].start == at(minutes=1)
+    assert gaps(at(seconds=37), at(minutes=30))[0].start == at(minutes=1)
+
+
+def test_the_window_end_rounds_backward() -> None:
+    assert gaps(NOON, at(minutes=30, seconds=59))[0].end == at(minutes=30)
+
+
+def test_an_occupied_stretch_splits_the_window() -> None:
+    occupied = [(at(minutes=20), at(minutes=30))]
+
+    assert gaps(NOON, at(minutes=60), occupied) == [
+        Gap(at(minutes=1), at(minutes=20)),
+        Gap(at(minutes=31), at(minutes=60)),
+    ]
+
+
+def test_a_gap_ends_on_the_whole_minute_before_an_occupied_stretch() -> None:
+    occupied = [(at(minutes=20, seconds=30), at(minutes=30))]
+
+    assert gaps(NOON, at(minutes=60), occupied)[0].end == at(minutes=20)
+
+
+def test_filling_resumes_on_the_whole_minute_after_an_occupied_stretch() -> None:
+    occupied = [(at(minutes=20), at(minutes=29, seconds=1))]
+
+    assert gaps(NOON, at(minutes=60), occupied)[1].start == at(minutes=30)
+
+
+def test_a_gap_of_exactly_the_minimum_is_left_empty() -> None:
+    """The boundary is exclusive: 300 seconds is too short, 360 is used."""
+    assert gaps(NOON, at(minutes=6)) == []
+    assert gaps(NOON, at(minutes=7)) == [Gap(at(minutes=1), at(minutes=7))]
+
+
+def test_an_item_overrunning_from_before_the_window_pushes_the_first_gap_back() -> None:
+    """The lead-in gap it leaves is negative-length and must not be yielded."""
+    occupied = [(at(minutes=-50), at(minutes=10))]
+
+    assert gaps(NOON, at(minutes=60), occupied) == [Gap(at(minutes=11), at(minutes=60))]
+
+
+def test_an_item_ending_before_the_window_is_ignored() -> None:
+    occupied = [(at(minutes=-10), at(minutes=-5))]
+
+    assert gaps(NOON, at(minutes=60), occupied) == [Gap(at(minutes=1), at(minutes=60))]
+
+
+def test_an_item_starting_after_the_window_is_ignored() -> None:
+    occupied = [(at(minutes=70), at(minutes=80))]
+
+    assert gaps(NOON, at(minutes=60), occupied) == [Gap(at(minutes=1), at(minutes=60))]
+
+
+def test_back_to_back_occupied_stretches_leave_no_gap_between_them() -> None:
+    occupied = [
+        (at(minutes=10), at(minutes=20)),
+        (at(minutes=20), at(minutes=30)),
+    ]
+
+    assert gaps(NOON, at(minutes=60), occupied) == [
+        Gap(at(minutes=1), at(minutes=10)),
+        Gap(at(minutes=31), at(minutes=60)),
+    ]
+
+
+def test_an_item_ending_exactly_at_a_resume_point_still_bounds_the_next_gap() -> None:
+    """Strict comparison: an item ending exactly where filling would resume
+    is not skipped as 'behind us'; it re-bounds the (then empty) gap."""
+    occupied = [
+        (at(minutes=10), at(minutes=20)),
+        (at(minutes=20, seconds=30), at(minutes=21)),
+    ]
+
+    assert gaps(NOON, at(minutes=60), occupied) == [
+        Gap(at(minutes=1), at(minutes=10)),
+        Gap(at(minutes=22), at(minutes=60)),
+    ]
+
+
+def test_occupied_stretches_shorter_than_the_gap_minimum_still_split() -> None:
+    """A one-minute item makes its own minute and both bounding minutes
+    unusable, but the remaining sides fill normally."""
+    occupied = [(at(minutes=30), at(minutes=31))]
+
+    assert gaps(NOON, at(minutes=60), occupied) == [
+        Gap(at(minutes=1), at(minutes=30)),
+        Gap(at(minutes=32), at(minutes=60)),
+    ]

--- a/agenda/tests/test_jukebox_fill.py
+++ b/agenda/tests/test_jukebox_fill.py
@@ -135,7 +135,7 @@ def test_two_videos_alternate_to_fill_the_time(db) -> None:
 
     res = jukebox.items_for_gap(START_DATE, end, videos)
 
-    assert [r["id"] for r in res] == [1, 2, 1, 2]
+    assert [r.video.id for r in res] == [1, 2, 1, 2]
 
 
 def test_short_gap_before_scheduled_item_is_left_empty(filler_video: Video) -> None:
@@ -162,8 +162,8 @@ def test_short_gap_before_scheduled_item_is_left_empty(filler_video: Video) -> N
 
     res = jukebox.items_for_gap(start, end, videos)
 
-    assert [r["id"] for r in res] == [1, 3, 1, 3]
-    assert [r["starttime"] for r in res] == [
+    assert [r.video.id for r in res] == [1, 3, 1, 3]
+    assert [r.starttime for r in res] == [
         START_DATE + datetime.timedelta(minutes=m) for m in (4, 6, 7, 9)
     ]
 
@@ -185,14 +185,14 @@ def test_saved_items_carry_the_start_and_duration_that_were_planned(filler_video
         START_DATE + datetime.timedelta(minutes=1 + 61 * n) for n in range(23)
     ]
     assert {item.duration for item in items} == {filler_video.duration}
-    assert [entry["starttime"] for entry in planned] == [item.starttime for item in items]
+    assert [entry.starttime for entry in planned] == [item.starttime for item in items]
 
 
 def test_filling_starts_on_the_minute_after_an_off_minute_start(filler_video: Video) -> None:
     """`next_whole_minute`, not `floor_minute`: a start mid-minute rounds forward."""
     planned = jukebox.fill_agenda_with_jukebox(START_DATE + datetime.timedelta(seconds=37), days=1)
 
-    assert planned[0]["starttime"] == START_DATE + datetime.timedelta(minutes=1)
+    assert planned[0].starttime == START_DATE + datetime.timedelta(minutes=1)
 
 
 def test_every_filler_in_the_pool_gets_used(member_organization: Organization) -> None:

--- a/agenda/tests/test_jukebox_fill.py
+++ b/agenda/tests/test_jukebox_fill.py
@@ -395,6 +395,32 @@ def test_a_positive_filler_shorter_than_a_minute_still_advances(
     assert starts == [START_DATE + datetime.timedelta(minutes=m) for m in range(1, 30)]
 
 
+def test_a_placement_whose_airtime_was_taken_since_planning_is_skipped(
+    filler_video: Video, short_filler: Video
+) -> None:
+    """
+    Between planning and saving, someone else's write can land on
+    airtime the plan counted as free -- there is no database exclusion
+    constraint yet to catch it. Saving re-checks each placement and
+    yields to whatever arrived; the rest of the plan still saves.
+    """
+    planned = jukebox.items_for_gap(
+        START_DATE, START_DATE + datetime.timedelta(hours=3), [filler_video]
+    )
+    assert len(planned) == 2
+    landed_meanwhile = planned[1]
+    occupy(
+        short_filler,
+        landed_meanwhile.starttime + datetime.timedelta(minutes=5),
+        datetime.timedelta(minutes=1),
+    )
+
+    saved = jukebox.save_placements(planned)
+
+    assert saved == [planned[0]]
+    assert overlapping_pairs() == []
+
+
 # --- the weighting rules, wired end to end ---------------------------------
 
 

--- a/agenda/tests/test_jukebox_fill.py
+++ b/agenda/tests/test_jukebox_fill.py
@@ -189,7 +189,7 @@ def test_saved_items_carry_the_start_and_duration_that_were_planned(filler_video
 
 
 def test_filling_starts_on_the_minute_after_an_off_minute_start(filler_video: Video) -> None:
-    """`ceil_minute`, not `floor_minute`: a start mid-minute rounds forward."""
+    """`next_whole_minute`, not `floor_minute`: a start mid-minute rounds forward."""
     planned = jukebox.fill_agenda_with_jukebox(START_DATE + datetime.timedelta(seconds=37), days=1)
 
     assert planned[0]["starttime"] == START_DATE + datetime.timedelta(minutes=1)

--- a/agenda/tests/test_jukebox_fill.py
+++ b/agenda/tests/test_jukebox_fill.py
@@ -255,6 +255,40 @@ def test_the_minimum_gap_boundary_is_exclusive(
     assert filled is expect_filled
 
 
+def test_an_overrunning_item_hidden_behind_a_nearer_one_still_counts(
+    filler_video: Video, short_filler: Video
+) -> None:
+    """
+    A long item from before the window can overrun into it even when a
+    nearer, non-overlapping item sits between its start and the window.
+    The old expand-to-the-previous-starttime approximation only looked
+    back as far as that nearer item and scheduled over the overrun.
+
+    The two pre-existing items overlap *each other* by construction --
+    that is the shape of the historical dirty data -- so the assertion
+    is only that the jukebox adds no overlap of its own.
+    """
+    occupy(
+        filler_video,
+        START_DATE - datetime.timedelta(hours=3),
+        datetime.timedelta(hours=4),
+    )
+    occupy(
+        short_filler,
+        START_DATE - datetime.timedelta(hours=1),
+        datetime.timedelta(minutes=30),
+    )
+
+    jukebox.fill_agenda_with_jukebox(START_DATE, days=HALF_HOUR + 1 / 24)
+
+    placed = Scheduleitem.objects.filter(schedulereason=Scheduleitem.REASON_JUKEBOX)
+    assert placed.exists()
+    for item in placed:
+        assert item.starttime >= START_DATE + datetime.timedelta(hours=1)
+        conflicts = Scheduleitem.objects.overlapping(item.starttime, item.endtime())
+        assert not conflicts.exclude(pk=item.pk).exists()
+
+
 def test_a_second_run_over_the_same_window_adds_nothing(filler_video: Video) -> None:
     """
     The cron runs nightly over windows that overlap the previous night's,

--- a/agenda/tests/test_jukebox_fill.py
+++ b/agenda/tests/test_jukebox_fill.py
@@ -399,17 +399,19 @@ def test_an_organization_dominating_the_slots_gets_diluted_filler(
 # --- the entry point the cron actually calls -------------------------------
 
 
-def test_the_management_command_fills_two_days_from_now(
+def test_the_management_command_fills_through_the_open_week(
     monkeypatch: pytest.MonkeyPatch, filler_video: Video
 ) -> None:
     """
     `fill_agenda_with_jukebox` is invoked by a nightly CronJob with no
-    arguments; the command supplies days=2 and lets the view default the
-    start to the current time.
+    arguments and drafts through the scheduling horizon: START_DATE is
+    Sunday noon of the week starting Mon 06-24, so the horizon is
+    Mon 07-15 00:00 -- a 20880-minute window holding 342 hour-long
+    fillers at 61-minute spacing.
     """
     monkeypatch.setattr(jukebox.timezone, "now", lambda: START_DATE)
 
     call_command("fill_agenda_with_jukebox")
 
     starts = list(Scheduleitem.objects.order_by("starttime").values_list("starttime", flat=True))
-    assert starts == [START_DATE + datetime.timedelta(minutes=1 + 61 * n) for n in range(47)]
+    assert starts == [START_DATE + datetime.timedelta(minutes=1 + 61 * n) for n in range(342)]

--- a/agenda/tests/test_jukebox_fill.py
+++ b/agenda/tests/test_jukebox_fill.py
@@ -14,6 +14,7 @@ one ceil for a floor changes what actually goes to air.
 """
 
 import datetime
+import random
 from itertools import pairwise
 from zoneinfo import ZoneInfo
 
@@ -197,9 +198,9 @@ def test_filling_starts_on_the_minute_after_an_off_minute_start(filler_video: Vi
 
 def test_every_filler_in_the_pool_gets_used(member_organization: Organization) -> None:
     """
-    The pool is drawn in random order (`order_by("?")`), so the sequence
-    is not pinned -- only that both videos are drawn and that neither is
-    played twice in a row.
+    The draw is weighted-random (no rng passed, so unseeded), and the
+    sequence is not pinned -- only that both videos are drawn and that
+    RepeatAvoidance keeps either from playing twice in a row.
     """
     first = make_filler(member_organization, name="First filler")
     second = make_filler(member_organization, name="Second filler")
@@ -358,6 +359,41 @@ def test_a_positive_filler_shorter_than_a_minute_still_advances(
 
     starts = list(Scheduleitem.objects.order_by("starttime").values_list("starttime", flat=True))
     assert starts == [START_DATE + datetime.timedelta(minutes=m) for m in range(1, 30)]
+
+
+# --- the weighting rules, wired end to end ---------------------------------
+
+
+def test_an_organization_dominating_the_slots_gets_diluted_filler(
+    member_organization: Organization,
+) -> None:
+    """
+    The selection context seeds from everything already on the air in
+    the window -- so six hours of slot programming from one organization
+    pushes the jukebox toward everyone else's fillers for the rest of
+    the day.  The draw is weighted-random (seeded here), a preference
+    rather than a quota, so the dominant organization still airs.
+    """
+    other_editor = User.objects.create(email="jukebox-other-org@example.test")
+    other_org = Organization.objects.create(name="Other org", fkmember=True, editor=other_editor)
+    slot_programming = make_filler(member_organization, name="Slot programming", is_filler=False)
+    dominant = [make_filler(member_organization, name=f"Dominant {n}", minutes=30) for n in "ab"]
+    minority = [
+        make_filler(other_org, name=f"Minority {n}", minutes=30, creator=other_editor) for n in "ab"
+    ]
+    occupy(slot_programming, START_DATE + datetime.timedelta(hours=1), datetime.timedelta(hours=6))
+
+    jukebox.fill_agenda_with_jukebox(START_DATE, days=1, rng=random.Random(1))
+
+    jukebox_items = Scheduleitem.objects.filter(schedulereason=Scheduleitem.REASON_JUKEBOX)
+    by_org = {
+        org.id: jukebox_items.filter(video__organization=org).count()
+        for org in (member_organization, other_org)
+    }
+    assert by_org[other_org.id] > by_org[member_organization.id]
+    assert by_org[member_organization.id] > 0
+    played = set(jukebox_items.values_list("video_id", flat=True))
+    assert played == {v.id for v in dominant + minority}
 
 
 # --- the entry point the cron actually calls -------------------------------

--- a/agenda/tests/test_policy.py
+++ b/agenda/tests/test_policy.py
@@ -10,6 +10,8 @@ edits, the agenda tests for the nightly fillers.
 import datetime
 from zoneinfo import ZoneInfo
 
+from django.utils import timezone
+
 from agenda.scheduling import policy
 
 OSLO = ZoneInfo("Europe/Oslo")
@@ -75,3 +77,15 @@ def test_boundaries_land_on_local_midnight_across_a_dst_transition() -> None:
 
 def test_the_freeze_message_names_the_open_monday() -> None:
     assert "2019-07-08" in policy.freeze_message(policy.freeze_boundary(NOW))
+
+
+def test_the_policy_ignores_the_active_django_timezone() -> None:
+    """fkweb.middleware overrides the active timezone to UTC for every
+    /api/ request. The policy is defined in Europe/Oslo regardless of
+    caller, or the API and the cron jobs would disagree about Monday
+    midnight by an hour or two."""
+    with timezone.override(datetime.UTC):
+        boundary = policy.freeze_boundary(NOW)
+
+    assert boundary == datetime.datetime(2019, 7, 8, tzinfo=OSLO)
+    assert "2019-07-08" in policy.freeze_message(boundary)

--- a/agenda/tests/test_policy.py
+++ b/agenda/tests/test_policy.py
@@ -1,0 +1,77 @@
+"""
+The broadcast-week lifecycle: drafted two Mondays ahead, open for one
+week, frozen from the Monday before airing.
+
+Pure clock arithmetic -- no database. The enforcement of these
+boundaries is tested where it lives: the schedule API tests for member
+edits, the agenda tests for the nightly fillers.
+"""
+
+import datetime
+from zoneinfo import ZoneInfo
+
+from agenda.scheduling import policy
+
+OSLO = ZoneInfo("Europe/Oslo")
+
+# A Thursday. Its broadcast week starts Monday 2019-06-24.
+NOW = datetime.datetime(2019, 6, 27, 12, tzinfo=OSLO)
+WEEK_START = datetime.datetime(2019, 6, 24, tzinfo=OSLO)
+
+
+def test_a_week_runs_monday_to_monday_local_time() -> None:
+    assert policy.week_start(NOW) == WEEK_START
+    monday_early = datetime.datetime(2019, 6, 24, 0, 0, 1, tzinfo=OSLO)
+    assert policy.week_start(monday_early) == WEEK_START
+    sunday_late = datetime.datetime(2019, 6, 30, 23, 59, tzinfo=OSLO)
+    assert policy.week_start(sunday_late) == WEEK_START
+
+
+def test_the_current_and_next_week_are_frozen() -> None:
+    assert policy.freeze_boundary(NOW) == WEEK_START + datetime.timedelta(weeks=2)
+
+    in_this_week = NOW + datetime.timedelta(days=1)
+    in_next_week = datetime.datetime(2019, 7, 3, tzinfo=OSLO)
+    in_open_week = datetime.datetime(2019, 7, 10, tzinfo=OSLO)
+    assert policy.is_frozen(in_this_week, now=NOW)
+    assert policy.is_frozen(in_next_week, now=NOW)
+    assert not policy.is_frozen(in_open_week, now=NOW)
+
+
+def test_the_freeze_boundary_is_inclusive_of_the_open_monday() -> None:
+    """An item starting exactly at Monday 00:00 of the open week is editable."""
+    boundary = policy.freeze_boundary(NOW)
+
+    assert not policy.is_frozen(boundary, now=NOW)
+    assert policy.is_frozen(boundary - datetime.timedelta(seconds=1), now=NOW)
+
+
+def test_a_week_freezes_the_moment_the_preceding_monday_arrives() -> None:
+    """Sunday 23:59 the week after next is open; one minute later it is not."""
+    airtime = datetime.datetime(2019, 7, 8, 12, tzinfo=OSLO)
+    sunday_night = datetime.datetime(2019, 6, 30, 23, 59, tzinfo=OSLO)
+    monday_morning = datetime.datetime(2019, 7, 1, 0, 0, tzinfo=OSLO)
+
+    assert not policy.is_frozen(airtime, now=sunday_night)
+    assert policy.is_frozen(airtime, now=monday_morning)
+
+
+def test_the_horizon_is_the_end_of_the_open_week() -> None:
+    assert policy.scheduling_horizon(NOW) == WEEK_START + datetime.timedelta(weeks=3)
+
+
+def test_boundaries_land_on_local_midnight_across_a_dst_transition() -> None:
+    """Oslo leaves DST on 2019-10-27; a naive `+ 14 days` on an aware
+    datetime would land on 23:00. The boundary must be a true local
+    midnight in the new offset."""
+    now = datetime.datetime(2019, 10, 16, 12, tzinfo=OSLO)  # Wednesday, CEST
+
+    boundary = policy.freeze_boundary(now)
+
+    assert boundary == datetime.datetime(2019, 10, 28, 0, 0, tzinfo=OSLO)
+    assert boundary.utcoffset() == datetime.timedelta(hours=1)
+    assert now.utcoffset() == datetime.timedelta(hours=2)
+
+
+def test_the_freeze_message_names_the_open_monday() -> None:
+    assert "2019-07-08" in policy.freeze_message(policy.freeze_boundary(NOW))

--- a/agenda/tests/test_round_robin_selector.py
+++ b/agenda/tests/test_round_robin_selector.py
@@ -5,6 +5,7 @@ pin the same behavior end to end through `items_for_gap`.
 """
 
 import datetime
+from itertools import pairwise
 
 from agenda.scheduling.jukebox import RoundRobinSelector
 from fk.models import Video
@@ -37,7 +38,7 @@ def test_no_video_repeats_until_the_rest_have_played() -> None:
 
     drawn = picks(selector, minutes(60), 10)
 
-    assert all(a != b for a, b in zip(drawn, drawn[1:], strict=False))
+    assert all(a != b for a, b in pairwise(drawn))
 
 
 def test_a_video_too_long_for_the_moment_keeps_its_place_in_line() -> None:

--- a/agenda/tests/test_round_robin_selector.py
+++ b/agenda/tests/test_round_robin_selector.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for RoundRobinSelector: the draw policy on its own, with no
+database and no clock. The integration tests in test_jukebox_fill.py
+pin the same behavior end to end through `items_for_gap`.
+"""
+
+import datetime
+
+from agenda.scheduling.jukebox import RoundRobinSelector
+from fk.models import Video
+
+
+def video(video_id: int, minutes: float = 10) -> Video:
+    return Video(
+        id=video_id,
+        name=f"id:{video_id}",
+        duration=datetime.timedelta(minutes=minutes),
+    )
+
+
+def minutes(n: float) -> datetime.timedelta:
+    return datetime.timedelta(minutes=n)
+
+
+def picks(selector: RoundRobinSelector, remaining: datetime.timedelta, n: int) -> list[int]:
+    return [selector.pick(remaining).id for _ in range(n)]
+
+
+def test_draws_in_the_order_given_and_cycles() -> None:
+    selector = RoundRobinSelector([video(1), video(2), video(3)])
+
+    assert picks(selector, minutes(60), 6) == [1, 2, 3, 1, 2, 3]
+
+
+def test_no_video_repeats_until_the_rest_have_played() -> None:
+    selector = RoundRobinSelector([video(1), video(2)])
+
+    drawn = picks(selector, minutes(60), 10)
+
+    assert all(a != b for a, b in zip(drawn, drawn[1:], strict=False))
+
+
+def test_a_video_too_long_for_the_moment_keeps_its_place_in_line() -> None:
+    selector = RoundRobinSelector([video(1, minutes=30), video(2, minutes=5)])
+
+    assert selector.pick(minutes(10)).id == 2
+    # With room again, the passed-over video goes first.
+    assert selector.pick(minutes(60)).id == 1
+
+
+def test_returns_none_when_nothing_fits() -> None:
+    selector = RoundRobinSelector([video(1, minutes=30)])
+
+    assert selector.pick(minutes(10)) is None
+
+
+def test_recovers_after_a_pick_that_found_nothing() -> None:
+    """A failed pick must not poison the next one: the pool tops back up."""
+    selector = RoundRobinSelector([video(1, minutes=30)])
+
+    assert selector.pick(minutes(10)) is None
+    assert selector.pick(minutes(60)).id == 1
+
+
+def test_an_empty_candidate_list_always_yields_none() -> None:
+    selector = RoundRobinSelector([])
+
+    assert selector.pick(minutes(60)) is None
+    assert selector.pick(minutes(60)) is None

--- a/agenda/tests/test_selection.py
+++ b/agenda/tests/test_selection.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for the jukebox's scoring rules and weighted draw.
+
+Everything here runs on unsaved Video instances and a hand-built
+ScheduleContext -- no database. test_jukebox_fill.py covers the wiring
+into fill_agenda_with_jukebox, including that the context seeds from
+the schedule already in the window.
+"""
+
+import datetime
+import random
+from itertools import pairwise
+from zoneinfo import ZoneInfo
+
+from agenda.scheduling.selection import (
+    Freshness,
+    OrganizationDiversity,
+    RepeatAvoidance,
+    ScheduleContext,
+    WeightedSelector,
+)
+from fk.models import Video
+
+OSLO = ZoneInfo("Europe/Oslo")
+NOW = datetime.datetime(2019, 6, 30, 12, tzinfo=OSLO)
+
+
+def video(
+    video_id: int,
+    minutes: float = 10,
+    organization_id: int | None = None,
+    uploaded_days_ago: float | None = None,
+) -> Video:
+    uploaded_time = None
+    if uploaded_days_ago is not None:
+        uploaded_time = NOW - datetime.timedelta(days=uploaded_days_ago)
+    return Video(
+        id=video_id,
+        name=f"id:{video_id}",
+        duration=datetime.timedelta(minutes=minutes),
+        organization_id=organization_id,
+        uploaded_time=uploaded_time,
+    )
+
+
+def minutes(n: float) -> datetime.timedelta:
+    return datetime.timedelta(minutes=n)
+
+
+# --- Freshness --------------------------------------------------------------
+
+
+def test_a_newer_upload_outweighs_an_older_one() -> None:
+    rule = Freshness(now=NOW)
+
+    fresh = rule.weight(video(1, uploaded_days_ago=7), None)
+    stale = rule.weight(video(2, uploaded_days_ago=3000), None)
+
+    assert fresh > stale
+
+
+def test_freshness_halves_per_half_life() -> None:
+    rule = Freshness(now=NOW, half_life=datetime.timedelta(days=100), floor=0.0)
+
+    assert rule.weight(video(1, uploaded_days_ago=0), None) == 1.0
+    assert rule.weight(video(1, uploaded_days_ago=100), None) == 0.5
+    assert rule.weight(video(1, uploaded_days_ago=200), None) == 0.25
+
+
+def test_ancient_and_undated_material_keeps_the_floor_weight() -> None:
+    """Old videos are downweighted, never frozen out."""
+    rule = Freshness(now=NOW, floor=0.2)
+
+    assert rule.weight(video(1, uploaded_days_ago=100_000), None) > 0.2 * 0.999
+    assert rule.weight(video(1, uploaded_days_ago=None), None) == 0.2
+
+
+def test_an_upload_dated_in_the_future_counts_as_brand_new() -> None:
+    rule = Freshness(now=NOW)
+
+    assert rule.weight(video(1, uploaded_days_ago=-1), None) == 1.0
+
+
+# --- OrganizationDiversity --------------------------------------------------
+
+
+def context_with_airtime(*org_minutes: tuple[int, float]) -> ScheduleContext:
+    context = ScheduleContext()
+    for i, (org_id, mins) in enumerate(org_minutes):
+        context.record(video(1000 + i, minutes=mins, organization_id=org_id))
+    return context
+
+
+def test_the_dominant_organizations_videos_weigh_less() -> None:
+    rule = OrganizationDiversity()
+    context = context_with_airtime((1, 45), (2, 15))
+
+    dominant = rule.weight(video(1, organization_id=1), context)
+    minority = rule.weight(video(2, organization_id=2), context)
+
+    assert dominant < minority
+
+
+def test_an_organization_with_no_airtime_yet_is_unpenalized() -> None:
+    rule = OrganizationDiversity()
+    context = context_with_airtime((1, 45))
+
+    assert rule.weight(video(2, organization_id=2), context) == 1.0
+
+
+def test_diversity_never_zeroes_a_candidate() -> None:
+    """A sole organization holds a share of 1.0; the floor keeps this a
+    preference rather than a veto, so RepeatAvoidance stays decisive."""
+    rule = OrganizationDiversity(floor=0.05)
+    context = context_with_airtime((1, 60))
+
+    assert rule.weight(video(1, organization_id=1), context) == 0.05
+
+
+# --- RepeatAvoidance --------------------------------------------------------
+
+
+def test_the_video_that_just_played_is_vetoed() -> None:
+    rule = RepeatAvoidance()
+    context = ScheduleContext()
+    context.record(video(1))
+
+    assert rule.weight(video(1), context) == 0.0
+    assert rule.weight(video(2), context) == 1.0
+
+
+def test_each_earlier_play_in_the_window_halves_the_weight() -> None:
+    rule = RepeatAvoidance(penalty=0.5)
+    context = ScheduleContext()
+    context.record(video(1))
+    context.record(video(1))
+    context.record(video(2))
+
+    assert rule.weight(video(1), context) == 0.25
+
+
+# --- ScheduleContext --------------------------------------------------------
+
+
+def test_airtime_shares_accumulate_as_picks_land() -> None:
+    context = context_with_airtime((1, 30), (2, 10))
+
+    assert context.organization_share(1) == 0.75
+    assert context.organization_share(2) == 0.25
+    assert context.organization_share(3) == 0.0
+    assert context.organization_share(None) == 0.0
+
+
+# --- WeightedSelector -------------------------------------------------------
+
+
+def selector(candidates, rules, seed=1) -> WeightedSelector:
+    return WeightedSelector(candidates, ScheduleContext(), rules, rng=random.Random(seed))
+
+
+def test_only_videos_that_fit_are_drawn() -> None:
+    chooser = selector([video(1, minutes=30), video(2, minutes=5)], rules=[])
+
+    assert chooser.pick(minutes(10)).id == 2
+    assert chooser.pick(minutes(3)) is None
+
+
+def test_picks_are_recorded_so_rules_see_them() -> None:
+    chooser = selector([video(1), video(2)], rules=[RepeatAvoidance()])
+
+    drawn = [chooser.pick(minutes(60)).id for _ in range(10)]
+
+    assert all(a != b for a, b in pairwise(drawn))
+
+
+def test_a_universally_vetoed_draw_falls_back_to_uniform() -> None:
+    """Dead air is worse than repetition: if the only video that fits
+    just played, it plays again."""
+    chooser = selector([video(1)], rules=[RepeatAvoidance()])
+
+    assert chooser.pick(minutes(60)).id == 1
+    assert chooser.pick(minutes(60)).id == 1
+
+
+def test_the_draw_follows_the_weights() -> None:
+    """With a 9:1 weight ratio, the heavier video dominates the tally."""
+
+    class Favor:
+        def weight(self, v, context):
+            return 0.9 if v.id == 1 else 0.1
+
+    chooser = selector([video(1), video(2)], rules=[Favor()], seed=42)
+
+    drawn = [chooser.pick(minutes(60)).id for _ in range(200)]
+
+    assert drawn.count(1) > 150
+
+
+def test_zero_length_candidates_are_never_drawn() -> None:
+    """A non-positive duration cannot advance the schedule clock."""
+    chooser = selector([video(1, minutes=0)], rules=[])
+
+    assert chooser.pick(minutes(60)) is None

--- a/api/auth/tests/conftest.py
+++ b/api/auth/tests/conftest.py
@@ -1,7 +1,9 @@
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
+from django.utils import timezone
 from rest_framework.test import APIClient
 
 from fk.models import (
@@ -14,6 +16,17 @@ from fk.models import (
     Video,
     VideoFile,
 )
+
+
+@pytest.fixture
+def now_in_the_drafting_week(monkeypatch: pytest.MonkeyPatch) -> datetime:
+    """Pin the clock so the 2015-01-01 scheduleitem fixture lands in the
+    open broadcast week (freeze boundary Mon 2014-12-29, see
+    agenda.scheduling.policy) -- the permission matrix is about *who*
+    may modify, so the freeze must not answer first."""
+    fixed_now = datetime(2014, 12, 17, 12, tzinfo=ZoneInfo("Europe/Oslo"))
+    monkeypatch.setattr(timezone, "now", lambda: fixed_now)
+    return fixed_now
 
 
 @pytest.fixture

--- a/api/auth/tests/test_permission_matrix.py
+++ b/api/auth/tests/test_permission_matrix.py
@@ -17,7 +17,7 @@ from rest_framework.test import APIClient
 
 from fk.models import AsRun, Category, Organization, Scheduleitem, Video, VideoFile
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("now_in_the_drafting_week")]
 
 DETAIL_URLS = {
     "video": "api-video-detail",

--- a/api/schedule/query_set.py
+++ b/api/schedule/query_set.py
@@ -78,35 +78,3 @@ class ScheduleitemQuerySet(models.QuerySet):
             _endtime=ExpressionWrapper(F("starttime") + F("duration"), output_field=DateTimeField())
         ).filter(starttime__lt=end_dt, _endtime__gt=start_dt)
 
-    def expand_to_surrounding(
-        self, start_dt: datetime, end_dt: datetime
-    ) -> tuple[datetime, datetime]:
-        """
-        Expand [start_dt, end_dt] to include the immediate event before start_dt
-        and the immediate event after end_dt, if they exist.
-
-        Performs at most two extra queries:
-          - one ORDER BY -starttime to find the latest <= start_dt
-          - one ORDER BY starttime to find the earliest >= end_dt
-        """
-        # previous event at or before start_dt
-        prev_start = (
-            self.filter(starttime__lte=start_dt)
-            .order_by("-starttime")
-            .values_list("starttime", flat=True)
-            .first()
-        )
-        if prev_start:
-            start_dt = prev_start
-
-        # next event at or after end_dt
-        next_start = (
-            self.filter(starttime__gte=end_dt)
-            .order_by("starttime")
-            .values_list("starttime", flat=True)
-            .first()
-        )
-        if next_start:
-            end_dt = next_start
-
-        return start_dt, end_dt

--- a/api/schedule/query_set.py
+++ b/api/schedule/query_set.py
@@ -77,4 +77,3 @@ class ScheduleitemQuerySet(models.QuerySet):
         return self.annotate(
             _endtime=ExpressionWrapper(F("starttime") + F("duration"), output_field=DateTimeField())
         ).filter(starttime__lt=end_dt, _endtime__gt=start_dt)
-

--- a/api/schedule/serializers.py
+++ b/api/schedule/serializers.py
@@ -66,20 +66,12 @@ class ScheduleitemModifySerializer(serializers.ModelSerializer):
 
             start = data.get("starttime", g("starttime"))
             end = start + data.get("duration", g("duration"))
-            conflicts = list(
-                Scheduleitem.objects.overlapping(start, end)
-                .exclude(pk=g("id"))
-                .order_by("starttime")
-            )
-            blocking = [
-                item for item in conflicts if item.schedulereason != Scheduleitem.REASON_JUKEBOX
-            ]
+            # Jukebox fillers do not block a pick, so only blocking
+            # conflicts refuse here. This early check is for the 400;
+            # save re-checks under lock before displacing.
+            blocking, _ = policy.airtime_conflicts(start, end, exclude_pk=g("id"))
             if blocking:
                 raise serializers.ValidationError({"duration": f"Conflict with '{blocking[0]}'."})
-            # Jukebox fillers do not block a pick: they are displaced
-            # when this saves, and the nightly jukebox repacks whatever
-            # slivers the displacement leaves behind.
-            self._displaced_fillers = conflicts
         return data
 
     def _enforce_freeze(self, data):
@@ -101,18 +93,40 @@ class ScheduleitemModifySerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         with transaction.atomic():
-            self._displace_fillers()
+            self._claim_airtime(validated_data, instance=None)
             return super().create(validated_data)
 
     def update(self, instance, validated_data):
         with transaction.atomic():
-            self._displace_fillers()
+            self._claim_airtime(validated_data, instance)
             return super().update(instance, validated_data)
 
-    def _displace_fillers(self):
-        displaced = getattr(self, "_displaced_fillers", None)
-        if displaced:
-            Scheduleitem.objects.filter(pk__in=[item.pk for item in displaced]).delete()
+    def _claim_airtime(self, validated_data, instance):
+        """Check-and-displace at save time, under row locks.
+
+        validate() already answered once, but without a database
+        exclusion constraint (blocked on historical overlapping rows) a
+        concurrent write between validation and save is the one overlap
+        source the application can still narrow: locking the conflict
+        rows serializes concurrent displacements of the same fillers,
+        and a blocking item that appeared since validation refuses here
+        instead of being scheduled over.
+        """
+
+        def current(field):
+            return validated_data.get(field, instance and getattr(instance, field))
+
+        start, duration = current("starttime"), current("duration")
+        if start is None or duration is None:
+            # A partial update that leaves the airtime untouched cannot
+            # create a new conflict.
+            return
+        blocking, displaceable = policy.airtime_conflicts(
+            start, start + duration, exclude_pk=instance and instance.pk, for_update=True
+        )
+        if blocking:
+            raise serializers.ValidationError({"duration": f"Conflict with '{blocking[0]}'."})
+        policy.displace(displaceable)
 
 
 class ScheduleitemReadSerializer(serializers.ModelSerializer):
@@ -135,7 +149,7 @@ class ScheduleitemReadSerializer(serializers.ModelSerializer):
         )
     )
     def get_displaceable(self, item) -> bool:
-        return item.schedulereason == Scheduleitem.REASON_JUKEBOX
+        return policy.is_displaceable(item)
 
 
 class SchedulingPolicySerializer(serializers.Serializer):

--- a/api/schedule/serializers.py
+++ b/api/schedule/serializers.py
@@ -1,7 +1,9 @@
 from zoneinfo import ZoneInfo
 
+from django.db import transaction
 from rest_framework import serializers
 
+from agenda.scheduling import policy
 from fk.models import AsRun, Category, Organization, Scheduleitem, Video, VideoFile
 
 
@@ -53,6 +55,7 @@ class ScheduleitemModifySerializer(serializers.ModelSerializer):
         fields = ("id", "video", "schedulereason", "starttime", "endtime", "duration")
 
     def validate(self, data):
+        self._enforce_freeze(data)
         if "starttime" in data or "duration" in data:
 
             def g(v):
@@ -60,15 +63,53 @@ class ScheduleitemModifySerializer(serializers.ModelSerializer):
 
             start = data.get("starttime", g("starttime"))
             end = start + data.get("duration", g("duration"))
-            conflict = (
+            conflicts = list(
                 Scheduleitem.objects.overlapping(start, end)
                 .exclude(pk=g("id"))
                 .order_by("starttime")
-                .first()
             )
-            if conflict:
-                raise serializers.ValidationError({"duration": f"Conflict with '{conflict}'."})
+            blocking = [
+                item for item in conflicts if item.schedulereason != Scheduleitem.REASON_JUKEBOX
+            ]
+            if blocking:
+                raise serializers.ValidationError({"duration": f"Conflict with '{blocking[0]}'."})
+            # Jukebox fillers do not block a pick: they are displaced
+            # when this saves, and the nightly jukebox repacks whatever
+            # slivers the displacement leaves behind.
+            self._displaced_fillers = conflicts
         return data
+
+    def _enforce_freeze(self, data):
+        """Members may only touch items in the open broadcast week.
+
+        Both positions matter on a move: an item may neither leave nor
+        land inside the frozen weeks. Staff is exempt (the same
+        exemption IsInOrganizationOrReadOnly grants on objects).
+        """
+        request = self.context.get("request")
+        if request is None or request.user.is_staff:
+            return
+        boundary = policy.freeze_boundary()
+        current_start = self.instance.starttime if self.instance else None
+        new_start = data.get("starttime", current_start)
+        for starttime in (current_start, new_start):
+            if starttime is not None and starttime < boundary:
+                raise serializers.ValidationError({"starttime": policy.freeze_message(boundary)})
+
+    def create(self, validated_data):
+        with transaction.atomic():
+            self._displace_fillers()
+            return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        with transaction.atomic():
+            self._displace_fillers()
+            return super().update(instance, validated_data)
+
+    def _displace_fillers(self):
+        displaced = getattr(self, "_displaced_fillers", None)
+        if displaced:
+            Scheduleitem.objects.filter(pk__in=[item.pk for item in displaced]).delete()
 
 
 class ScheduleitemReadSerializer(serializers.ModelSerializer):

--- a/api/schedule/serializers.py
+++ b/api/schedule/serializers.py
@@ -1,10 +1,13 @@
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from agenda.scheduling import policy
 from fk.models import AsRun, Category, Organization, Scheduleitem, Video, VideoFile
+
+OSLO = ZoneInfo("Europe/Oslo")
 
 
 class ScheduleitemVideoFileSerializer(serializers.ModelSerializer):
@@ -47,8 +50,8 @@ class ScheduleitemVideoSerializer(serializers.ModelSerializer):
 
 
 class ScheduleitemModifySerializer(serializers.ModelSerializer):
-    starttime = serializers.DateTimeField(default_timezone=ZoneInfo("Europe/Oslo"))
-    endtime = serializers.DateTimeField(default_timezone=ZoneInfo("Europe/Oslo"), read_only=True)
+    starttime = serializers.DateTimeField(default_timezone=OSLO)
+    endtime = serializers.DateTimeField(default_timezone=OSLO, read_only=True)
 
     class Meta:
         model = Scheduleitem
@@ -114,12 +117,58 @@ class ScheduleitemModifySerializer(serializers.ModelSerializer):
 
 class ScheduleitemReadSerializer(serializers.ModelSerializer):
     video = ScheduleitemVideoSerializer()
-    starttime = serializers.DateTimeField(default_timezone=ZoneInfo("Europe/Oslo"))
-    endtime = serializers.DateTimeField(default_timezone=ZoneInfo("Europe/Oslo"), read_only=True)
+    starttime = serializers.DateTimeField(default_timezone=OSLO)
+    endtime = serializers.DateTimeField(default_timezone=OSLO, read_only=True)
+    displaceable = serializers.SerializerMethodField()
 
     class Meta:
         model = Scheduleitem
-        fields = ("id", "video", "starttime", "endtime")
+        fields = ("id", "video", "starttime", "endtime", "displaceable")
+
+    @extend_schema_field(
+        serializers.BooleanField(
+            help_text="Whether this item is automatic jukebox filler, which a member "
+            "organization's own pick replaces when scheduled over it. Deliberate "
+            "programming is never displaceable. Only meaningful for items starting at "
+            "or after the freezeBoundary of /api/scheduling/policy; frozen airtime "
+            "cannot be changed regardless."
+        )
+    )
+    def get_displaceable(self, item) -> bool:
+        return item.schedulereason == Scheduleitem.REASON_JUKEBOX
+
+
+class SchedulingPolicySerializer(serializers.Serializer):
+    """The broadcast-week policy, as instants to compare schedule items
+    against. Clients should derive per-item state from these rather than
+    re-implement the week arithmetic (see agenda.scheduling.policy):
+    items before freezeBoundary are frozen, items between freezeBoundary
+    and schedulingHorizon are in the open week, and airtime beyond
+    schedulingHorizon has not been drafted yet.
+    """
+
+    freeze_boundary = serializers.DateTimeField(
+        default_timezone=OSLO,
+        read_only=True,
+        help_text="Schedule items starting before this instant are frozen: member "
+        "organizations can no longer create, move, edit, or delete them. It is the "
+        "Monday midnight (Europe/Oslo) before the open broadcast week, and advances "
+        "one week every Monday at midnight.",
+    )
+    scheduling_horizon = serializers.DateTimeField(
+        default_timezone=OSLO,
+        read_only=True,
+        help_text="The end of the drafted schedule: the open week runs from "
+        "freezeBoundary to here. The nightly jobs do not schedule beyond this "
+        "instant, and neither should clients present later airtime as available.",
+    )
+    server_time = serializers.DateTimeField(
+        default_timezone=OSLO,
+        read_only=True,
+        help_text="The server's clock when this response was produced. Compare "
+        "against it, not the local clock, when deciding which side of a boundary "
+        "the present moment falls on.",
+    )
 
 
 class AsRunSerializer(serializers.ModelSerializer):

--- a/api/schedule/tests/conftest.py
+++ b/api/schedule/tests/conftest.py
@@ -1,10 +1,24 @@
 from collections.abc import Callable
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
+from django.utils import timezone
 from rest_framework.test import APIClient
 
 from fk.models import Organization, Scheduleitem, User, Video
+
+
+@pytest.fixture
+def now_in_the_drafting_week(monkeypatch: pytest.MonkeyPatch) -> datetime:
+    """Pin the clock so the 2015-01-01 fixtures land in the *open*
+    broadcast week: with now in the week of Mon 2014-12-15, the freeze
+    boundary is Mon 2014-12-29 and the open week runs through Sunday
+    2015-01-04 (see agenda.scheduling.policy). Modify-path tests need
+    this; the read path never consults the freeze."""
+    fixed_now = datetime(2014, 12, 17, 12, tzinfo=ZoneInfo("Europe/Oslo"))
+    monkeypatch.setattr(timezone, "now", lambda: fixed_now)
+    return fixed_now
 
 
 @pytest.fixture

--- a/api/schedule/tests/test_api.py
+++ b/api/schedule/tests/test_api.py
@@ -11,7 +11,7 @@ from rest_framework.test import APIClient
 
 from fk.models import Scheduleitem, Video
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("now_in_the_drafting_week")]
 
 OSLO = ZoneInfo("Europe/Oslo")
 

--- a/api/schedule/tests/test_detail_api.py
+++ b/api/schedule/tests/test_detail_api.py
@@ -9,7 +9,7 @@ from rest_framework.test import APIClient
 
 from fk.models import Scheduleitem
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("now_in_the_drafting_week")]
 
 HISTORICAL_START = datetime(2015, 1, 1, 10, tzinfo=ZoneInfo("Europe/Oslo"))
 

--- a/api/schedule/tests/test_freeze_policy.py
+++ b/api/schedule/tests/test_freeze_policy.py
@@ -1,0 +1,209 @@
+"""
+The broadcast-week policy at the API boundary (agenda.scheduling.policy):
+members may edit only the open week, their picks displace jukebox
+fillers, and staff is exempt.
+
+The pinned clock puts the freeze boundary at Mon 2014-12-29; the open
+week is 2014-12-29 through 2015-01-04.
+"""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from fk.models import Organization, Scheduleitem, User, Video
+
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("now_in_the_drafting_week")]
+
+OSLO = ZoneInfo("Europe/Oslo")
+IN_THE_OPEN_WEEK = datetime(2015, 1, 1, 10, tzinfo=OSLO)
+IN_THE_FROZEN_WEEK = datetime(2014, 12, 25, 10, tzinfo=OSLO)
+OPEN_MONDAY = "2014-12-29"
+
+
+@pytest.fixture
+def member(organization: Organization) -> User:
+    user = User.objects.create(email="freeze-member@example.test")
+    organization.members.add(user)
+    return user
+
+
+@pytest.fixture
+def member_client(member: User) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=member)
+    return client
+
+
+@pytest.fixture
+def staff_client() -> APIClient:
+    """The freeze exemption follows is_staff (a superuser alias on this
+    User model), like IsInOrganizationOrReadOnly's."""
+    client = APIClient()
+    client.force_authenticate(
+        user=User.objects.create(email="freeze-staff@example.test", is_superuser=True)
+    )
+    return client
+
+
+@pytest.fixture
+def other_organization() -> Organization:
+    editor = User.objects.create(email="freeze-other-editor@example.test")
+    return Organization.objects.create(name="Other org", editor=editor)
+
+
+def jukebox_filler_at(
+    organization: Organization, starttime: datetime, minutes: int = 60
+) -> Scheduleitem:
+    filler = Video.objects.create(
+        creator=organization.editor,
+        name="Jukebox filler",
+        organization=organization,
+        duration=timedelta(minutes=minutes),
+        proper_import=True,
+        is_filler=True,
+    )
+    return Scheduleitem.objects.create(
+        video=filler,
+        starttime=starttime,
+        duration=filler.duration,
+        schedulereason=Scheduleitem.REASON_JUKEBOX,
+    )
+
+
+def post_item(client: APIClient, video: Video, starttime: datetime):
+    return client.post(
+        reverse("api-scheduleitem-list"),
+        {
+            "video": video.pk,
+            "starttime": starttime.isoformat(),
+            "duration": "01:00:00",
+            "schedulereason": Scheduleitem.REASON_USER,
+        },
+        format="json",
+    )
+
+
+# --- the freeze -------------------------------------------------------------
+
+
+def test_members_cannot_schedule_into_the_frozen_weeks(
+    member_client: APIClient, video: Video
+) -> None:
+    response = post_item(member_client, video, IN_THE_FROZEN_WEEK)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert OPEN_MONDAY in str(response.data)
+    assert not Scheduleitem.objects.exists()
+
+
+def test_members_cannot_move_an_item_into_the_frozen_weeks(
+    member_client: APIClient, schedule_item_factory
+) -> None:
+    item = schedule_item_factory(starttime=IN_THE_OPEN_WEEK)
+
+    response = member_client.patch(
+        reverse("api-scheduleitem-detail", args=[item.pk]),
+        {"starttime": IN_THE_FROZEN_WEEK.isoformat()},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    item.refresh_from_db()
+    assert item.starttime == IN_THE_OPEN_WEEK
+
+
+def test_members_cannot_touch_an_item_already_in_the_frozen_weeks(
+    member_client: APIClient, schedule_item_factory
+) -> None:
+    """Even an edit that keeps the airtime (or no airtime change at all)
+    is refused: the published week is fixed in content, not just shape."""
+    item = schedule_item_factory(starttime=IN_THE_FROZEN_WEEK)
+
+    patch_response = member_client.patch(
+        reverse("api-scheduleitem-detail", args=[item.pk]),
+        {"duration": "00:30:00"},
+        format="json",
+    )
+    delete_response = member_client.delete(reverse("api-scheduleitem-detail", args=[item.pk]))
+
+    assert patch_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert delete_response.status_code == status.HTTP_403_FORBIDDEN
+    item.refresh_from_db()
+    assert item.duration == timedelta(hours=1)
+
+
+def test_members_can_edit_the_open_week(member_client: APIClient, video: Video) -> None:
+    response = post_item(member_client, video, IN_THE_OPEN_WEEK)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Scheduleitem.objects.get().starttime == IN_THE_OPEN_WEEK
+
+
+def test_staff_may_change_the_frozen_weeks(staff_client: APIClient, video: Video) -> None:
+    create_response = post_item(staff_client, video, IN_THE_FROZEN_WEEK)
+    item_pk = create_response.data["id"]
+    delete_response = staff_client.delete(reverse("api-scheduleitem-detail", args=[item_pk]))
+
+    assert create_response.status_code == status.HTTP_201_CREATED
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+
+# --- displacement of jukebox fillers ----------------------------------------
+
+
+def test_a_member_pick_displaces_jukebox_fillers(
+    member_client: APIClient, video: Video, other_organization: Organization
+) -> None:
+    """Fillers belong to some other organization's video, so members
+    could never delete them directly; a pick overlapping only fillers
+    replaces them in one step."""
+    fully_covered = jukebox_filler_at(other_organization, IN_THE_OPEN_WEEK)
+    straddling = jukebox_filler_at(
+        other_organization, IN_THE_OPEN_WEEK + timedelta(minutes=30), minutes=60
+    )
+
+    response = post_item(member_client, video, IN_THE_OPEN_WEEK)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    remaining = Scheduleitem.objects.get()
+    assert remaining.video == video
+    assert not Scheduleitem.objects.filter(pk__in=[fully_covered.pk, straddling.pk]).exists()
+
+
+def test_displacement_also_applies_when_moving_an_item(
+    member_client: APIClient, schedule_item_factory, other_organization: Organization
+) -> None:
+    item = schedule_item_factory(starttime=IN_THE_OPEN_WEEK)
+    target = IN_THE_OPEN_WEEK + timedelta(hours=3)
+    filler = jukebox_filler_at(other_organization, target)
+
+    response = member_client.patch(
+        reverse("api-scheduleitem-detail", args=[item.pk]),
+        {"starttime": target.isoformat()},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert not Scheduleitem.objects.filter(pk=filler.pk).exists()
+    item.refresh_from_db()
+    assert item.starttime == target
+
+
+def test_a_conflict_with_deliberate_programming_still_refuses(
+    member_client: APIClient, video: Video, schedule_item_factory, other_organization: Organization
+) -> None:
+    """Only REASON_JUKEBOX gives way. A manual item on the same airtime
+    is a conflict, and the fillers beside it survive the refusal."""
+    filler = jukebox_filler_at(other_organization, IN_THE_OPEN_WEEK)
+    deliberate = schedule_item_factory(starttime=IN_THE_OPEN_WEEK + timedelta(minutes=30))
+
+    response = post_item(member_client, video, IN_THE_OPEN_WEEK)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Conflict" in str(response.data)
+    assert Scheduleitem.objects.filter(pk__in=[filler.pk, deliberate.pk]).count() == 2

--- a/api/schedule/tests/test_freeze_policy.py
+++ b/api/schedule/tests/test_freeze_policy.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from agenda.scheduling.jukebox import fill_agenda_with_jukebox
 from fk.models import Organization, Scheduleitem, User, Video
 
 pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("now_in_the_drafting_week")]
@@ -52,8 +53,9 @@ def staff_client() -> APIClient:
 
 @pytest.fixture
 def other_organization() -> Organization:
+    """fkmember, so its fillers are eligible when the jukebox refills."""
     editor = User.objects.create(email="freeze-other-editor@example.test")
-    return Organization.objects.create(name="Other org", editor=editor)
+    return Organization.objects.create(name="Other org", editor=editor, fkmember=True)
 
 
 def jukebox_filler_at(
@@ -192,6 +194,39 @@ def test_displacement_also_applies_when_moving_an_item(
     assert not Scheduleitem.objects.filter(pk=filler.pk).exists()
     item.refresh_from_db()
     assert item.starttime == target
+
+
+def test_the_nightly_jukebox_repacks_what_a_displacement_orphans(
+    member_client: APIClient, video: Video, other_organization: Organization
+) -> None:
+    """A pick over the last 5 minutes of a 50-minute filler deletes the
+    whole filler, orphaning the ~45 minutes in front of the pick. The
+    nightly jukebox walks the entire window again, so the next run
+    repacks that stretch -- here with the same 50-minute video, twice,
+    leaving only a sub-minimum sliver before the pick.
+    """
+    filler_item = jukebox_filler_at(other_organization, IN_THE_OPEN_WEEK, minutes=50)
+    pick_start = IN_THE_OPEN_WEEK + timedelta(minutes=45)
+
+    response = post_item(member_client, video, pick_start)
+    assert response.status_code == status.HTTP_201_CREATED
+    assert not Scheduleitem.objects.filter(pk=filler_item.pk).exists()
+
+    fill_agenda_with_jukebox(start=IN_THE_OPEN_WEEK - timedelta(hours=1), days=0.25)
+
+    refills = Scheduleitem.objects.filter(
+        schedulereason=Scheduleitem.REASON_JUKEBOX, starttime__lt=pick_start
+    ).order_by("starttime")
+    # 09:01 and 09:52: packed from the whole minute after the window
+    # opens up to the pick, ending 10:42 -- a 3-minute leftover, below
+    # the jukebox's 5-minute minimum.
+    assert [item.starttime for item in refills] == [
+        IN_THE_OPEN_WEEK - timedelta(minutes=59),
+        IN_THE_OPEN_WEEK - timedelta(minutes=8),
+    ]
+    assert refills.last().endtime() <= pick_start
+    later = Scheduleitem.objects.filter(starttime__gte=pick_start).order_by("starttime")
+    assert later.first().starttime == pick_start  # the pick survived intact
 
 
 def test_a_conflict_with_deliberate_programming_still_refuses(

--- a/api/schedule/tests/test_list_api.py
+++ b/api/schedule/tests/test_list_api.py
@@ -279,6 +279,7 @@ def test_list_serializes_nested_video_details(
             },
             "starttime": "2015-01-02T10:00:00+01:00",
             "endtime": "2015-01-02T11:00:00+01:00",
+            "displaceable": False,
         }
     ]
 

--- a/api/schedule/tests/test_permissions.py
+++ b/api/schedule/tests/test_permissions.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 
 from fk.models import Organization, Scheduleitem, User, Video
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("now_in_the_drafting_week")]
 
 OSLO = ZoneInfo("Europe/Oslo")
 SCHEDULE_START = datetime(2015, 1, 1, 10, tzinfo=OSLO)

--- a/api/schedule/tests/test_policy_endpoint.py
+++ b/api/schedule/tests/test_policy_endpoint.py
@@ -1,0 +1,75 @@
+"""
+How the broadcast-week policy reaches the frontend: the read-only
+/api/scheduling/policy endpoint, the `displaceable` flag on schedule
+items, and both being visible to drf-spectacular.
+
+The frontend derives every UI state from these -- frozen, open,
+replaceable filler, not yet drafted -- rather than re-implementing the
+week arithmetic of agenda.scheduling.policy.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+from django.urls import reverse
+from django.utils.dateparse import parse_datetime
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from agenda.scheduling import policy
+from fk.models import Scheduleitem
+
+pytestmark = pytest.mark.django_db
+
+OSLO = ZoneInfo("Europe/Oslo")
+
+
+def test_the_policy_endpoint_is_public_and_states_the_boundaries(
+    now_in_the_drafting_week: datetime,
+) -> None:
+    response = APIClient().get(reverse("api-scheduling-policy"))
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert parse_datetime(payload["freezeBoundary"]) == policy.freeze_boundary(
+        now_in_the_drafting_week
+    )
+    assert parse_datetime(payload["schedulingHorizon"]) == policy.scheduling_horizon(
+        now_in_the_drafting_week
+    )
+    assert parse_datetime(payload["serverTime"]) == now_in_the_drafting_week
+
+
+def test_the_boundaries_are_rendered_in_oslo_time(now_in_the_drafting_week: datetime) -> None:
+    """Members read these as wall-clock deadlines; the offset must be
+    Norway's, not UTC."""
+    payload = APIClient().get(reverse("api-scheduling-policy")).json()
+
+    assert payload["freezeBoundary"] == "2014-12-29T00:00:00+01:00"
+    assert payload["schedulingHorizon"] == "2015-01-05T00:00:00+01:00"
+
+
+def test_schedule_items_say_whether_they_are_displaceable(schedule_item_factory) -> None:
+    filler = schedule_item_factory(starttime=datetime(2015, 1, 1, 10, tzinfo=OSLO))
+    filler.schedulereason = Scheduleitem.REASON_JUKEBOX
+    filler.save()
+    pick = schedule_item_factory(starttime=datetime(2015, 1, 1, 12, tzinfo=OSLO))
+
+    response = APIClient().get(reverse("api-scheduleitem-list"), {"date": "2015-01-01"})
+
+    by_id = {entry["id"]: entry["displaceable"] for entry in response.json()["results"]}
+    assert by_id == {filler.pk: True, pick.pk: False}
+
+
+def test_the_openapi_schema_documents_the_policy(db) -> None:
+    """drf-spectacular must see the endpoint and the flag: the schema
+    names the operation, the response component's camelized fields, and
+    the displaceable property with its description."""
+    schema = APIClient().get(reverse("schema")).content.decode()
+
+    assert "scheduling_policy_retrieve" in schema
+    assert "/api/scheduling/policy" in schema
+    for field in ("freezeBoundary", "schedulingHorizon", "serverTime", "displaceable"):
+        assert field in schema
+    assert "jukebox filler" in schema

--- a/api/schedule/views.py
+++ b/api/schedule/views.py
@@ -1,6 +1,8 @@
 from django.db.models import Prefetch
 from rest_framework import viewsets
+from rest_framework.exceptions import PermissionDenied
 
+from agenda.scheduling import policy
 from api.auth.permissions import IsInOrganizationOrReadOnly, RequireTargetOrganizationMembership
 from api.pagination import FkSchedulePagination
 from api.schedule.filters import ScheduleitemFilter
@@ -47,3 +49,10 @@ class ScheduleitemViewSet(RequireTargetOrganizationMembership, viewsets.ModelVie
         if self.action in ["create", "update", "partial_update"]:
             return ScheduleitemModifySerializer
         return ScheduleitemReadSerializer
+
+    def perform_destroy(self, instance):
+        # Create and update enforce the freeze in the serializer; delete
+        # never reaches one, so the check lives here.
+        if not self.request.user.is_staff and policy.is_frozen(instance.starttime):
+            raise PermissionDenied(policy.freeze_message())
+        instance.delete()

--- a/api/schedule/views.py
+++ b/api/schedule/views.py
@@ -1,12 +1,20 @@
 from django.db.models import Prefetch
-from rest_framework import viewsets
+from django.utils import timezone
+from drf_spectacular.utils import extend_schema
+from rest_framework import permissions, viewsets
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from agenda.scheduling import policy
 from api.auth.permissions import IsInOrganizationOrReadOnly, RequireTargetOrganizationMembership
 from api.pagination import FkSchedulePagination
 from api.schedule.filters import ScheduleitemFilter
-from api.schedule.serializers import ScheduleitemModifySerializer, ScheduleitemReadSerializer
+from api.schedule.serializers import (
+    ScheduleitemModifySerializer,
+    ScheduleitemReadSerializer,
+    SchedulingPolicySerializer,
+)
 from fk.models import Scheduleitem, VideoFile
 
 
@@ -56,3 +64,40 @@ class ScheduleitemViewSet(RequireTargetOrganizationMembership, viewsets.ModelVie
         if not self.request.user.is_staff and policy.is_frozen(instance.starttime):
             raise PermissionDenied(policy.freeze_message())
         instance.delete()
+
+
+class SchedulingPolicyView(APIView):
+    """The broadcast-week policy boundaries, for clients to compare
+    schedule items against instead of re-deriving the week arithmetic."""
+
+    permission_classes = (permissions.AllowAny,)
+
+    @extend_schema(
+        operation_id="scheduling_policy_retrieve",
+        summary="Broadcast-week scheduling policy",
+        description=(
+            "The instants that divide the broadcast schedule into its three "
+            "states. Every broadcast week runs Monday 00:00 to Monday 00:00, "
+            "Europe/Oslo, and is drafted two Mondays before it airs, open for "
+            "member changes for one week, then frozen from the Monday before "
+            "airing.\n\n"
+            "Derive per-item state by comparing `starttime` against these "
+            "boundaries: before `freezeBoundary` the item is frozen; from "
+            "`freezeBoundary` up to `schedulingHorizon` it is in the open week, "
+            "where an item marked `displaceable` can be replaced by a member "
+            "organization's own pick; beyond `schedulingHorizon` nothing is "
+            "drafted yet. The values only change on Mondays at midnight "
+            "Europe/Oslo. Staff accounts are exempt from the freeze."
+        ),
+        responses=SchedulingPolicySerializer,
+    )
+    def get(self, request):
+        now = timezone.now()
+        serializer = SchedulingPolicySerializer(
+            {
+                "freeze_boundary": policy.freeze_boundary(now),
+                "scheduling_horizon": policy.scheduling_horizon(now),
+                "server_time": now,
+            }
+        )
+        return Response(serializer.data)

--- a/api/urls.py
+++ b/api/urls.py
@@ -83,6 +83,17 @@ urlpatterns += router.urls
 # Format suffixes
 urlpatterns = format_suffix_patterns(urlpatterns, allowed=["json", "api", "xml"])
 
+urlpatterns += [
+    # Registered after the format-suffix expansion on purpose: a
+    # `.json`-style twin would only clutter the OpenAPI schema with a
+    # colliding {format} operation.
+    path(
+        "api/scheduling/policy",
+        schedule_views.SchedulingPolicyView.as_view(),
+        name="api-scheduling-policy",
+    ),
+]
+
 # Default login/logout views
 urlpatterns += [
     # Spectacular API views


### PR DESCRIPTION
## What this is

Two connected pieces of work on `agenda.scheduling`, done as 12 commits meant to be read in order.

### 1. The jukebox becomes an architecture instead of an algorithm (5 commits)

The old `_fill_time_with_jukebox` interleaved gap discovery, draw policy, and persistence in one loop with pool/rejects state threaded through return values. It is now three separated stages:

- `free_gaps()` — pure gap arithmetic over `(start, end)` pairs, every whole-minute boundary rule unit-tested without the database
- selection — `agenda/scheduling/selection.py`, a weighted-random draw over multiplicative scoring rules with an injectable RNG:
  - **Freshness**: half the weight per year of upload age, floored so ancient material still airs
  - **OrganizationDiversity**: weight falls with the organization's share of the window's airtime — weekly-slot programming included, so an organization the slots favor gets its fillers downplayed automatically
  - **RepeatAvoidance**: never the same video twice in a row; each earlier play in the window halves the weight
  - Preference rules floor above zero; only RepeatAvoidance may veto, and a universally-vetoed draw falls back to uniform — dead air is worse than repetition
- planning/persistence — typed `Placement`s, and a save step that re-checks each placement's airtime

New criteria ("don't let one org dominate a day") are now a small class with `weight(video, context)` appended to `default_rules()`.

### 2. The broadcast-week lifecycle (7 commits)

The schedule now has a policy explainable to members in three sentences, held in one module (`agenda/scheduling/policy.py`):

> Every broadcast week (Monday–Monday, Europe/Oslo) is **drafted two Mondays before it airs** — slots place their videos, the jukebox fills the rest. For the following week, **member picks displace jukebox fillers** through the API. From the Monday before airing, **the week is frozen** (staff excepted; the jukebox may still fill genuinely empty airtime).

Enforcement and exposure:

- API: members cannot create/move/edit/delete anything starting before the freeze boundary; in the open week, a pick colliding only with jukebox fillers deletes them in the same transaction. Conflicts with deliberate programming still refuse.
- Weekly slots place **every** occurrence up to the horizon and displace fillers outside the freeze, so a new slot doesn't wait two weeks for airtime.
- `GET /api/scheduling/policy` gives clients `freezeBoundary` / `schedulingHorizon` / `serverTime` as instants to compare against, and schedule items gain a `displaceable` flag — fully described for drf-spectacular, zero schema warnings added.
- The cron manifests are unchanged: same commands, new defaults.

### Bugs found and fixed along the way

- `fkweb.middleware` forces UTC for `/api/` requests, so the policy's week arithmetic was Oslo-anchored from cron but UTC-anchored in API requests — freeze checks an hour or two off. The policy now pins `Europe/Oslo` itself, with a regression test under `timezone.override(UTC)`.
- The jukebox's occupied-airtime approximation missed a long item overrunning the window from behind a nearer non-overlapping item; it now uses `overlapping()`, the codebase's one definition.
- The slot filler's displace-then-create was not atomic.
- Displacement/conflict checks now run at save time under `select_for_update`, and the jukebox re-checks per placement before writing. This narrows the no-DB-constraint race (the exclusion constraint remains blocked on historical overlapping rows) but cannot close it — noted honestly in the code.

### Notes for deploy

The first nightly run after this lands fills ~2.5 weeks in one go, and next week's schedule is born already frozen — members get their first editing window for the week after next. If a gentler transition is wanted, deploy the cron commits first and the API-freeze commit a week later.

355 tests (was 283 at branch point), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
